### PR TITLE
Allow custom implementations of native types

### DIFF
--- a/src/Internal/Internal.Native.cs
+++ b/src/Internal/Internal.Native.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Numerics;
 using System.Runtime.InteropServices;
 using System.Security;
 
@@ -40,7 +41,7 @@ namespace NWN
 
         [SuppressUnmanagedCodeSecurity]
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        public delegate void StackPushVectorDelegate(Vector value);
+        public delegate void StackPushVectorDelegate(Vector3 value);
 
         [SuppressUnmanagedCodeSecurity]
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -84,7 +85,7 @@ namespace NWN
 
         [SuppressUnmanagedCodeSecurity]
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        public delegate Vector StackPopVectorDelegate();
+        public delegate Vector3 StackPopVectorDelegate();
 
         [SuppressUnmanagedCodeSecurity]
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]

--- a/src/NWNX/EffectPlugin.cs
+++ b/src/NWNX/EffectPlugin.cs
@@ -10,10 +10,10 @@ namespace NWNX
         // / @brief Convert native effect type to unpacked structure.
         // / @param e The effect to convert.
         // / @return A constructed NWNX_EffectUnpacked.
-        public static EffectUnpacked UnpackEffect(NWN.Effect e)
+        public static EffectUnpacked UnpackEffect(System.IntPtr e)
         {
             NWN.Internal.NativeFunctions.nwnxSetFunction(NWNX_Effect, "UnpackEffect");
-            NWN.Internal.NativeFunctions.nwnxPushEffect(e.Handle);
+            NWN.Internal.NativeFunctions.nwnxPushEffect(e);
             NWN.Internal.NativeFunctions.nwnxCallFunction();
             EffectUnpacked retVal;
             retVal.sTag = NWN.Internal.NativeFunctions.nwnxPopString();
@@ -41,9 +41,9 @@ namespace NWNX
             retVal.nParam0 = NWN.Internal.NativeFunctions.nwnxPopInt();
             retVal.nNumIntegers = NWN.Internal.NativeFunctions.nwnxPopInt();
             retVal.bLinkRightValid = NWN.Internal.NativeFunctions.nwnxPopInt();
-            retVal.eLinkRight = new NWN.Effect(NWN.Internal.NativeFunctions.nwnxPopEffect());
+            retVal.eLinkRight = NWN.Internal.NativeFunctions.nwnxPopEffect();
             retVal.bLinkLeftValid = NWN.Internal.NativeFunctions.nwnxPopInt();
-            retVal.eLinkLeft = new NWN.Effect(NWN.Internal.NativeFunctions.nwnxPopEffect());
+            retVal.eLinkLeft = NWN.Internal.NativeFunctions.nwnxPopEffect();
             retVal.nCasterLevel = NWN.Internal.NativeFunctions.nwnxPopInt();
             retVal.bShowIcon = NWN.Internal.NativeFunctions.nwnxPopInt();
             retVal.bExpose = NWN.Internal.NativeFunctions.nwnxPopInt();
@@ -60,7 +60,7 @@ namespace NWNX
         // / @brief Convert unpacked effect structure to native type.
         // / @param e The NWNX_EffectUnpacked structure to convert.
         // / @return The effect.
-        public static NWN.Effect PackEffect(EffectUnpacked e)
+        public static System.IntPtr PackEffect(EffectUnpacked e)
         {
             NWN.Internal.NativeFunctions.nwnxSetFunction(NWNX_Effect, "PackEffect");
             NWN.Internal.NativeFunctions.nwnxPushInt(e.nType);
@@ -73,9 +73,9 @@ namespace NWNX
             NWN.Internal.NativeFunctions.nwnxPushInt(e.bExpose);
             NWN.Internal.NativeFunctions.nwnxPushInt(e.bShowIcon);
             NWN.Internal.NativeFunctions.nwnxPushInt(e.nCasterLevel);
-            NWN.Internal.NativeFunctions.nwnxPushEffect(e.eLinkLeft.Handle);
+            NWN.Internal.NativeFunctions.nwnxPushEffect(e.eLinkLeft);
             NWN.Internal.NativeFunctions.nwnxPushInt(e.bLinkLeftValid);
-            NWN.Internal.NativeFunctions.nwnxPushEffect(e.eLinkRight.Handle);
+            NWN.Internal.NativeFunctions.nwnxPushEffect(e.eLinkRight);
             NWN.Internal.NativeFunctions.nwnxPushInt(e.bLinkRightValid);
             NWN.Internal.NativeFunctions.nwnxPushInt(e.nNumIntegers);
             NWN.Internal.NativeFunctions.nwnxPushInt(e.nParam0);
@@ -102,7 +102,7 @@ namespace NWNX
             NWN.Internal.NativeFunctions.nwnxPushObject(e.oParam3);
             NWN.Internal.NativeFunctions.nwnxPushString(e.sTag);
             NWN.Internal.NativeFunctions.nwnxCallFunction();
-            return new NWN.Effect(NWN.Internal.NativeFunctions.nwnxPopEffect());
+            return NWN.Internal.NativeFunctions.nwnxPopEffect();
         }
 
         // / @brief Set a script with optional data that runs when an effect expires
@@ -111,14 +111,14 @@ namespace NWNX
         // / @param data Any other data you wish to send back to the script.
         // / @remark OBJECT_SELF in the script is the object the effect is applied to.
         // / @note Only works for TEMPORARY and PERMANENT effects applied to an object.
-        public static NWN.Effect SetEffectExpiredScript(NWN.Effect e, string script, string data = "")
+        public static System.IntPtr SetEffectExpiredScript(System.IntPtr e, string script, string data = "")
         {
             NWN.Internal.NativeFunctions.nwnxSetFunction(NWNX_Effect, "SetEffectExpiredScript");
             NWN.Internal.NativeFunctions.nwnxPushString(data);
             NWN.Internal.NativeFunctions.nwnxPushString(script);
-            NWN.Internal.NativeFunctions.nwnxPushEffect(e.Handle);
+            NWN.Internal.NativeFunctions.nwnxPushEffect(e);
             NWN.Internal.NativeFunctions.nwnxCallFunction();
-            return new NWN.Effect(NWN.Internal.NativeFunctions.nwnxPopEffect());
+            return NWN.Internal.NativeFunctions.nwnxPopEffect();
         }
 
         // / @brief Get the data set with NWNX_Effect_SetEffectExpiredScript()
@@ -156,9 +156,9 @@ namespace NWNX
             public int bExpose;
             public int bShowIcon;
             public int nCasterLevel;
-            public NWN.Effect eLinkLeft;
+            public System.IntPtr eLinkLeft;
             public int bLinkLeftValid;
-            public NWN.Effect eLinkRight;
+            public System.IntPtr eLinkRight;
             public int bLinkRightValid;
             public int nNumIntegers;
             public int nParam0;

--- a/src/NWNX/ItempropPlugin.cs
+++ b/src/NWNX/ItempropPlugin.cs
@@ -10,10 +10,10 @@ namespace NWNX
         // / @brief Convert native itemproperty type to unpacked structure.
         // / @param ip The itemproperty to convert.
         // / @return A constructed NWNX_IPUnpacked.
-        public static IPUnpacked UnpackIP(NWN.ItemProperty ip)
+        public static IPUnpacked UnpackIP(System.IntPtr ip)
         {
             NWN.Internal.NativeFunctions.nwnxSetFunction(NWNX_ItemProperty, "UnpackIP");
-            NWN.Internal.NativeFunctions.nwnxPushItemProperty(ip.Handle);
+            NWN.Internal.NativeFunctions.nwnxPushItemProperty(ip);
             NWN.Internal.NativeFunctions.nwnxCallFunction();
             IPUnpacked retVal;
             retVal.sTag = NWN.Internal.NativeFunctions.nwnxPopString();
@@ -34,7 +34,7 @@ namespace NWNX
         // / @brief Convert unpacked itemproperty structure to native type.
         // / @param ip The NWNX_IPUnpacked structure to convert.
         // / @return The itemproperty.
-        public static NWN.ItemProperty PackIP(IPUnpacked ip)
+        public static System.IntPtr PackIP(IPUnpacked ip)
         {
             NWN.Internal.NativeFunctions.nwnxSetFunction(NWNX_ItemProperty, "PackIP");
             NWN.Internal.NativeFunctions.nwnxPushInt(ip.nProperty);
@@ -50,7 +50,7 @@ namespace NWNX
             NWN.Internal.NativeFunctions.nwnxPushObject(ip.oCreator);
             NWN.Internal.NativeFunctions.nwnxPushString(ip.sTag);
             NWN.Internal.NativeFunctions.nwnxCallFunction();
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.nwnxPopItemProperty());
+            return NWN.Internal.NativeFunctions.nwnxPopItemProperty();
         }
 
         // / @}

--- a/src/NWNX/ObjectPlugin.cs
+++ b/src/NWNX/ObjectPlugin.cs
@@ -82,12 +82,12 @@ namespace NWNX
         // / @brief Set an object's position.
         // / @param obj The object.
         // / @param pos A vector position.
-        public static void SetPosition(uint obj, NWN.Vector pos)
+        public static void SetPosition(uint obj, System.Numerics.Vector3 pos)
         {
             NWN.Internal.NativeFunctions.nwnxSetFunction(NWNX_Object, "SetPosition");
-            NWN.Internal.NativeFunctions.nwnxPushFloat(pos.z);
-            NWN.Internal.NativeFunctions.nwnxPushFloat(pos.y);
-            NWN.Internal.NativeFunctions.nwnxPushFloat(pos.x);
+            NWN.Internal.NativeFunctions.nwnxPushFloat(pos.Z);
+            NWN.Internal.NativeFunctions.nwnxPushFloat(pos.Y);
+            NWN.Internal.NativeFunctions.nwnxPushFloat(pos.X);
             NWN.Internal.NativeFunctions.nwnxPushObject(obj);
             NWN.Internal.NativeFunctions.nwnxCallFunction();
         }
@@ -227,12 +227,12 @@ namespace NWNX
         // / @param obj The object.
         // / @param area The area.
         // / @param pos The position.
-        public static void AddToArea(uint obj, uint area, NWN.Vector pos)
+        public static void AddToArea(uint obj, uint area, System.Numerics.Vector3 pos)
         {
             NWN.Internal.NativeFunctions.nwnxSetFunction(NWNX_Object, "AddToArea");
-            NWN.Internal.NativeFunctions.nwnxPushFloat(pos.z);
-            NWN.Internal.NativeFunctions.nwnxPushFloat(pos.y);
-            NWN.Internal.NativeFunctions.nwnxPushFloat(pos.x);
+            NWN.Internal.NativeFunctions.nwnxPushFloat(pos.Z);
+            NWN.Internal.NativeFunctions.nwnxPushFloat(pos.Y);
+            NWN.Internal.NativeFunctions.nwnxPushFloat(pos.X);
             NWN.Internal.NativeFunctions.nwnxPushObject(area);
             NWN.Internal.NativeFunctions.nwnxPushObject(obj);
             NWN.Internal.NativeFunctions.nwnxCallFunction();
@@ -605,12 +605,12 @@ namespace NWNX
         // / @param oTrigger The trigger.
         // / @param vPosition The position.
         // / @return TRUE if vPosition is inside oTrigger's geometry.
-        public static int GetPositionIsInTrigger(uint oTrigger, NWN.Vector vPosition)
+        public static int GetPositionIsInTrigger(uint oTrigger, System.Numerics.Vector3 vPosition)
         {
             NWN.Internal.NativeFunctions.nwnxSetFunction(NWNX_Object, "GetPositionIsInTrigger");
-            NWN.Internal.NativeFunctions.nwnxPushFloat(vPosition.z);
-            NWN.Internal.NativeFunctions.nwnxPushFloat(vPosition.y);
-            NWN.Internal.NativeFunctions.nwnxPushFloat(vPosition.x);
+            NWN.Internal.NativeFunctions.nwnxPushFloat(vPosition.Z);
+            NWN.Internal.NativeFunctions.nwnxPushFloat(vPosition.Y);
+            NWN.Internal.NativeFunctions.nwnxPushFloat(vPosition.X);
             NWN.Internal.NativeFunctions.nwnxPushObject(oTrigger);
             NWN.Internal.NativeFunctions.nwnxCallFunction();
             return NWN.Internal.NativeFunctions.nwnxPopInt();

--- a/src/NWNX/PlayerPlugin.cs
+++ b/src/NWNX/PlayerPlugin.cs
@@ -180,12 +180,12 @@ namespace NWNX
         // / @param player The player object.
         // / @param effectId The effect id.
         // / @param position The position to play the visual effect.
-        public static void ShowVisualEffect(uint player, int effectId, NWN.Vector position)
+        public static void ShowVisualEffect(uint player, int effectId, System.Numerics.Vector3 position)
         {
             NWN.Internal.NativeFunctions.nwnxSetFunction(NWNX_Player, "ShowVisualEffect");
-            NWN.Internal.NativeFunctions.nwnxPushFloat(position.z);
-            NWN.Internal.NativeFunctions.nwnxPushFloat(position.y);
-            NWN.Internal.NativeFunctions.nwnxPushFloat(position.x);
+            NWN.Internal.NativeFunctions.nwnxPushFloat(position.Z);
+            NWN.Internal.NativeFunctions.nwnxPushFloat(position.Y);
+            NWN.Internal.NativeFunctions.nwnxPushFloat(position.X);
             NWN.Internal.NativeFunctions.nwnxPushInt(effectId);
             NWN.Internal.NativeFunctions.nwnxPushObject(player);
             NWN.Internal.NativeFunctions.nwnxCallFunction();

--- a/src/NWNX/UtilPlugin.cs
+++ b/src/NWNX/UtilPlugin.cs
@@ -75,24 +75,24 @@ namespace NWNX
         // / @brief Convert an effect type to an itemproperty type.
         // / @param e The effect to convert to an itemproperty.
         // / @return The converted itemproperty.
-        public static NWN.ItemProperty EffectToItemProperty(NWN.Effect e)
+        public static System.IntPtr EffectToItemProperty(System.IntPtr e)
         {
             NWN.Internal.NativeFunctions.nwnxSetFunction(NWNX_Util, "EffectToItemProperty");
-            NWN.Internal.NativeFunctions.nwnxPushEffect(e.Handle);
+            NWN.Internal.NativeFunctions.nwnxPushEffect(e);
             NWN.Internal.NativeFunctions.nwnxCallFunction();
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.nwnxPopItemProperty());
+            return NWN.Internal.NativeFunctions.nwnxPopItemProperty();
         }
 
         // /
         // / @brief Convert an itemproperty type to an effect type.
         // / @param ip The itemproperty to convert to an effect.
         // / @return The converted effect.
-        public static NWN.Effect ItemPropertyToEffect(NWN.ItemProperty ip)
+        public static System.IntPtr ItemPropertyToEffect(System.IntPtr ip)
         {
             NWN.Internal.NativeFunctions.nwnxSetFunction(NWNX_Util, "ItemPropertyToEffect");
-            NWN.Internal.NativeFunctions.nwnxPushItemProperty(ip.Handle);
+            NWN.Internal.NativeFunctions.nwnxPushItemProperty(ip);
             NWN.Internal.NativeFunctions.nwnxCallFunction();
-            return new NWN.Effect(NWN.Internal.NativeFunctions.nwnxPopEffect());
+            return NWN.Internal.NativeFunctions.nwnxPopEffect();
         }
 
         // / @brief Strip any color codes from a string.

--- a/src/Native/Functions.cs
+++ b/src/Native/Functions.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Numerics;
+
 namespace NWN
 {
     public partial class NWScript
@@ -268,10 +271,10 @@ namespace NWN
         ///  * No return value, but if an error occurs the log file will contain
         ///    "MoveToPoint failed."
         /// </summary>
-        public static void ActionMoveToLocation(NWN.Location lDestination, int bRun = FALSE)
+        public static void ActionMoveToLocation(IntPtr lDestination, int bRun = FALSE)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(bRun);
-            NWN.Internal.NativeFunctions.StackPushLocation(lDestination.Handle);
+            NWN.Internal.NativeFunctions.StackPushLocation(lDestination);
             NWN.Internal.NativeFunctions.CallBuiltIn(21);
         }
 
@@ -354,7 +357,7 @@ namespace NWN
         ///  Get the position of oTarget
         ///  * Return value on error: vector (0.0f, 0.0f, 0.0f)
         /// </summary>
-        public static NWN.Vector GetPosition(uint oTarget)
+        public static Vector3 GetPosition(uint oTarget)
         {
             NWN.Internal.NativeFunctions.StackPushObject(oTarget);
             NWN.Internal.NativeFunctions.CallBuiltIn(27);
@@ -1008,11 +1011,11 @@ namespace NWN
         ///  Create a Heal effect. This should be applied as an instantaneous effect.
         ///  * Returns an effect of type EFFECT_TYPE_INVALIDEFFECT if nDamageToHeal < 0.
         /// </summary>
-        public static NWN.Effect EffectHeal(int nDamageToHeal)
+        public static IntPtr EffectHeal(int nDamageToHeal)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nDamageToHeal);
             NWN.Internal.NativeFunctions.CallBuiltIn(78);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -1022,25 +1025,25 @@ namespace NWN
         ///  - nDamageType: DAMAGE_TYPE_*
         ///  - nDamagePower: DAMAGE_POWER_*
         /// </summary>
-        public static NWN.Effect EffectDamage(int nDamageAmount, int nDamageType = DAMAGE_TYPE_MAGICAL, int nDamagePower = DAMAGE_POWER_NORMAL)
+        public static IntPtr EffectDamage(int nDamageAmount, int nDamageType = DAMAGE_TYPE_MAGICAL, int nDamagePower = DAMAGE_POWER_NORMAL)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nDamagePower);
             NWN.Internal.NativeFunctions.StackPushInteger(nDamageType);
             NWN.Internal.NativeFunctions.StackPushInteger(nDamageAmount);
             NWN.Internal.NativeFunctions.CallBuiltIn(79);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
         ///  Create an Ability Increase effect
         ///  - bAbilityToIncrease: ABILITY_*
         /// </summary>
-        public static NWN.Effect EffectAbilityIncrease(int nAbilityToIncrease, int nModifyBy)
+        public static IntPtr EffectAbilityIncrease(int nAbilityToIncrease, int nModifyBy)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nModifyBy);
             NWN.Internal.NativeFunctions.StackPushInteger(nAbilityToIncrease);
             NWN.Internal.NativeFunctions.CallBuiltIn(80);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -1050,22 +1053,22 @@ namespace NWN
         ///  - nAmount
         ///  - nLimit
         /// </summary>
-        public static NWN.Effect EffectDamageResistance(int nDamageType, int nAmount, int nLimit = 0)
+        public static IntPtr EffectDamageResistance(int nDamageType, int nAmount, int nLimit = 0)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nLimit);
             NWN.Internal.NativeFunctions.StackPushInteger(nAmount);
             NWN.Internal.NativeFunctions.StackPushInteger(nDamageType);
             NWN.Internal.NativeFunctions.CallBuiltIn(81);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
         ///  Create a Resurrection effect. This should be applied as an instantaneous effect.
         /// </summary>
-        public static NWN.Effect EffectResurrection()
+        public static IntPtr EffectResurrection()
         {
             NWN.Internal.NativeFunctions.CallBuiltIn(82);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -1079,14 +1082,14 @@ namespace NWN
         ///    summoned. If zero, it will just fade in somewhere near the target.  If the value is 1
         ///    it will use the appear animation, and if it's 2 it will use appear2 (which doesn't exist for most creatures)
         /// </summary>
-        public static NWN.Effect EffectSummonCreature(string sCreatureResref, int nVisualEffectId = VFX_NONE, float fDelaySeconds = 0.0f, int nUseAppearAnimation = 0)
+        public static IntPtr EffectSummonCreature(string sCreatureResref, int nVisualEffectId = VFX_NONE, float fDelaySeconds = 0.0f, int nUseAppearAnimation = 0)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nUseAppearAnimation);
             NWN.Internal.NativeFunctions.StackPushFloat(fDelaySeconds);
             NWN.Internal.NativeFunctions.StackPushInteger(nVisualEffectId);
             NWN.Internal.NativeFunctions.StackPushStringUTF8(sCreatureResref);
             NWN.Internal.NativeFunctions.CallBuiltIn(83);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -1103,30 +1106,30 @@ namespace NWN
         /// <summary>
         ///  Get the first in-game effect on oCreature.
         /// </summary>
-        public static NWN.Effect GetFirstEffect(uint oCreature)
+        public static IntPtr GetFirstEffect(uint oCreature)
         {
             NWN.Internal.NativeFunctions.StackPushObject(oCreature);
             NWN.Internal.NativeFunctions.CallBuiltIn(85);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
         ///  Get the next in-game effect on oCreature.
         /// </summary>
-        public static NWN.Effect GetNextEffect(uint oCreature)
+        public static IntPtr GetNextEffect(uint oCreature)
         {
             NWN.Internal.NativeFunctions.StackPushObject(oCreature);
             NWN.Internal.NativeFunctions.CallBuiltIn(86);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
         ///  Remove eEffect from oCreature.
         ///  * No return value
         /// </summary>
-        public static void RemoveEffect(uint oCreature, NWN.Effect eEffect)
+        public static void RemoveEffect(uint oCreature, IntPtr eEffect)
         {
-            NWN.Internal.NativeFunctions.StackPushEffect(eEffect.Handle);
+            NWN.Internal.NativeFunctions.StackPushEffect(eEffect);
             NWN.Internal.NativeFunctions.StackPushObject(oCreature);
             NWN.Internal.NativeFunctions.CallBuiltIn(87);
         }
@@ -1135,9 +1138,9 @@ namespace NWN
         ///  * Returns TRUE if eEffect is a valid effect. The effect must have been applied to
         ///  * an object or else it will return FALSE
         /// </summary>
-        public static int GetIsEffectValid(NWN.Effect eEffect)
+        public static int GetIsEffectValid(IntPtr eEffect)
         {
-            NWN.Internal.NativeFunctions.StackPushEffect(eEffect.Handle);
+            NWN.Internal.NativeFunctions.StackPushEffect(eEffect);
             NWN.Internal.NativeFunctions.CallBuiltIn(88);
             return NWN.Internal.NativeFunctions.StackPopInteger();
         }
@@ -1146,9 +1149,9 @@ namespace NWN
         ///  Get the duration type (DURATION_TYPE_*) of eEffect.
         ///  * Return value if eEffect is not valid: -1
         /// </summary>
-        public static int GetEffectDurationType(NWN.Effect eEffect)
+        public static int GetEffectDurationType(IntPtr eEffect)
         {
-            NWN.Internal.NativeFunctions.StackPushEffect(eEffect.Handle);
+            NWN.Internal.NativeFunctions.StackPushEffect(eEffect);
             NWN.Internal.NativeFunctions.CallBuiltIn(89);
             return NWN.Internal.NativeFunctions.StackPopInteger();
         }
@@ -1157,9 +1160,9 @@ namespace NWN
         ///  Get the subtype (SUBTYPE_*) of eEffect.
         ///  * Return value on error: 0
         /// </summary>
-        public static int GetEffectSubType(NWN.Effect eEffect)
+        public static int GetEffectSubType(IntPtr eEffect)
         {
-            NWN.Internal.NativeFunctions.StackPushEffect(eEffect.Handle);
+            NWN.Internal.NativeFunctions.StackPushEffect(eEffect);
             NWN.Internal.NativeFunctions.CallBuiltIn(90);
             return NWN.Internal.NativeFunctions.StackPopInteger();
         }
@@ -1168,9 +1171,9 @@ namespace NWN
         ///  Get the object that created eEffect.
         ///  * Returns OBJECT_INVALID if eEffect is not a valid effect.
         /// </summary>
-        public static uint GetEffectCreator(NWN.Effect eEffect)
+        public static uint GetEffectCreator(IntPtr eEffect)
         {
-            NWN.Internal.NativeFunctions.StackPushEffect(eEffect.Handle);
+            NWN.Internal.NativeFunctions.StackPushEffect(eEffect);
             NWN.Internal.NativeFunctions.CallBuiltIn(91);
             return NWN.Internal.NativeFunctions.StackPopObject();
         }
@@ -1314,9 +1317,9 @@ namespace NWN
         ///  distance between two points.
         ///  * Return value on error: 0.0f
         /// </summary>
-        public static float VectorMagnitude(NWN.Vector? vVector)
+        public static float VectorMagnitude(Vector3? vVector)
         {
-            NWN.Internal.NativeFunctions.StackPushVector(vVector.HasValue ? vVector.Value : new NWN.Vector());
+            NWN.Internal.NativeFunctions.StackPushVector(vVector.HasValue ? vVector.Value : new Vector3());
             NWN.Internal.NativeFunctions.CallBuiltIn(104);
             return NWN.Internal.NativeFunctions.StackPopFloat();
         }
@@ -1434,11 +1437,11 @@ namespace NWN
         ///  (Effects default to magical if the subtype is not set)
         ///  Magical effects are removed by resting, and by dispel magic
         /// </summary>
-        public static NWN.Effect MagicalEffect(NWN.Effect eEffect)
+        public static IntPtr MagicalEffect(IntPtr eEffect)
         {
-            NWN.Internal.NativeFunctions.StackPushEffect(eEffect.Handle);
+            NWN.Internal.NativeFunctions.StackPushEffect(eEffect);
             NWN.Internal.NativeFunctions.CallBuiltIn(112);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -1446,11 +1449,11 @@ namespace NWN
         ///  (Effects default to magical if the subtype is not set)
         ///  Permanent supernatural effects are not removed by resting
         /// </summary>
-        public static NWN.Effect SupernaturalEffect(NWN.Effect eEffect)
+        public static IntPtr SupernaturalEffect(IntPtr eEffect)
         {
-            NWN.Internal.NativeFunctions.StackPushEffect(eEffect.Handle);
+            NWN.Internal.NativeFunctions.StackPushEffect(eEffect);
             NWN.Internal.NativeFunctions.CallBuiltIn(113);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -1458,11 +1461,11 @@ namespace NWN
         ///  (Effects default to magical if the subtype is not set)
         ///  Extraordinary effects are removed by resting, but not by dispel magic
         /// </summary>
-        public static NWN.Effect ExtraordinaryEffect(NWN.Effect eEffect)
+        public static IntPtr ExtraordinaryEffect(IntPtr eEffect)
         {
-            NWN.Internal.NativeFunctions.StackPushEffect(eEffect.Handle);
+            NWN.Internal.NativeFunctions.StackPushEffect(eEffect);
             NWN.Internal.NativeFunctions.CallBuiltIn(114);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -1472,13 +1475,13 @@ namespace NWN
         ///  - nDamageType: DAMAGE_TYPE_*
         ///    * Default value for nDamageType should only ever be used in this function prototype.
         /// </summary>
-        public static NWN.Effect EffectACIncrease(int nValue, int nModifyType = AC_DODGE_BONUS, int nDamageType = AC_VS_DAMAGE_TYPE_ALL)
+        public static IntPtr EffectACIncrease(int nValue, int nModifyType = AC_DODGE_BONUS, int nDamageType = AC_VS_DAMAGE_TYPE_ALL)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nDamageType);
             NWN.Internal.NativeFunctions.StackPushInteger(nModifyType);
             NWN.Internal.NativeFunctions.StackPushInteger(nValue);
             NWN.Internal.NativeFunctions.CallBuiltIn(115);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -1505,13 +1508,13 @@ namespace NWN
         ///  - nValue: size of the Saving Throw increase
         ///  - nSaveType: SAVING_THROW_TYPE_* (e.g. SAVING_THROW_TYPE_ACID )
         /// </summary>
-        public static NWN.Effect EffectSavingThrowIncrease(int nSave, int nValue, int nSaveType = SAVING_THROW_TYPE_ALL)
+        public static IntPtr EffectSavingThrowIncrease(int nSave, int nValue, int nSaveType = SAVING_THROW_TYPE_ALL)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nSaveType);
             NWN.Internal.NativeFunctions.StackPushInteger(nValue);
             NWN.Internal.NativeFunctions.StackPushInteger(nSave);
             NWN.Internal.NativeFunctions.CallBuiltIn(117);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -1519,12 +1522,12 @@ namespace NWN
         ///  - nBonus: size of attack bonus
         ///  - nModifierType: ATTACK_BONUS_*
         /// </summary>
-        public static NWN.Effect EffectAttackIncrease(int nBonus, int nModifierType = ATTACK_BONUS_MISC)
+        public static IntPtr EffectAttackIncrease(int nBonus, int nModifierType = ATTACK_BONUS_MISC)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nModifierType);
             NWN.Internal.NativeFunctions.StackPushInteger(nBonus);
             NWN.Internal.NativeFunctions.CallBuiltIn(118);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -1534,13 +1537,13 @@ namespace NWN
         ///  - nLimit: How much damage the effect can absorb before disappearing.
         ///    Set to zero for infinite
         /// </summary>
-        public static NWN.Effect EffectDamageReduction(int nAmount, int nDamagePower, int nLimit = 0)
+        public static IntPtr EffectDamageReduction(int nAmount, int nDamagePower, int nLimit = 0)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nLimit);
             NWN.Internal.NativeFunctions.StackPushInteger(nDamagePower);
             NWN.Internal.NativeFunctions.StackPushInteger(nAmount);
             NWN.Internal.NativeFunctions.CallBuiltIn(119);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -1550,12 +1553,12 @@ namespace NWN
         ///  NOTE! You *must* use the DAMAGE_BONUS_* constants! Using other values may
         ///        result in odd behaviour.
         /// </summary>
-        public static NWN.Effect EffectDamageIncrease(int nBonus, int nDamageType = DAMAGE_TYPE_MAGICAL)
+        public static IntPtr EffectDamageIncrease(int nBonus, int nDamageType = DAMAGE_TYPE_MAGICAL)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nDamageType);
             NWN.Internal.NativeFunctions.StackPushInteger(nBonus);
             NWN.Internal.NativeFunctions.CallBuiltIn(120);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -1666,12 +1669,12 @@ namespace NWN
         ///    origin of the effect(normally the spell-caster's position).
         ///  Return value on error: OBJECT_INVALID
         /// </summary>
-        public static uint GetFirstObjectInShape(int nShape, float fSize, NWN.Location lTarget, int bLineOfSight = FALSE, int nObjectFilter = OBJECT_TYPE_CREATURE, NWN.Vector? vOrigin = null)
+        public static uint GetFirstObjectInShape(int nShape, float fSize, IntPtr lTarget, int bLineOfSight = FALSE, int nObjectFilter = OBJECT_TYPE_CREATURE, Vector3? vOrigin = null)
         {
-            NWN.Internal.NativeFunctions.StackPushVector(vOrigin.HasValue ? vOrigin.Value : new NWN.Vector());
+            NWN.Internal.NativeFunctions.StackPushVector(vOrigin.HasValue ? vOrigin.Value : new Vector3());
             NWN.Internal.NativeFunctions.StackPushInteger(nObjectFilter);
             NWN.Internal.NativeFunctions.StackPushInteger(bLineOfSight);
-            NWN.Internal.NativeFunctions.StackPushLocation(lTarget.Handle);
+            NWN.Internal.NativeFunctions.StackPushLocation(lTarget);
             NWN.Internal.NativeFunctions.StackPushFloat(fSize);
             NWN.Internal.NativeFunctions.StackPushInteger(nShape);
             NWN.Internal.NativeFunctions.CallBuiltIn(128);
@@ -1704,12 +1707,12 @@ namespace NWN
         ///    of the effect (normally the spell-caster's position).
         ///  Return value on error: OBJECT_INVALID
         /// </summary>
-        public static uint GetNextObjectInShape(int nShape, float fSize, NWN.Location lTarget, int bLineOfSight = FALSE, int nObjectFilter = OBJECT_TYPE_CREATURE, NWN.Vector? vOrigin = null)
+        public static uint GetNextObjectInShape(int nShape, float fSize, IntPtr lTarget, int bLineOfSight = FALSE, int nObjectFilter = OBJECT_TYPE_CREATURE, Vector3? vOrigin = null)
         {
-            NWN.Internal.NativeFunctions.StackPushVector(vOrigin.HasValue ? vOrigin.Value : new NWN.Vector());
+            NWN.Internal.NativeFunctions.StackPushVector(vOrigin.HasValue ? vOrigin.Value : new Vector3());
             NWN.Internal.NativeFunctions.StackPushInteger(nObjectFilter);
             NWN.Internal.NativeFunctions.StackPushInteger(bLineOfSight);
-            NWN.Internal.NativeFunctions.StackPushLocation(lTarget.Handle);
+            NWN.Internal.NativeFunctions.StackPushLocation(lTarget);
             NWN.Internal.NativeFunctions.StackPushFloat(fSize);
             NWN.Internal.NativeFunctions.StackPushInteger(nShape);
             NWN.Internal.NativeFunctions.CallBuiltIn(129);
@@ -1721,10 +1724,10 @@ namespace NWN
         ///  When applied, this effect will restrict the creature's movement and apply a
         ///  (-2) to all attacks and a -4 to AC.
         /// </summary>
-        public static NWN.Effect EffectEntangle()
+        public static IntPtr EffectEntangle()
         {
             NWN.Internal.NativeFunctions.CallBuiltIn(130);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -1742,9 +1745,9 @@ namespace NWN
         ///     EventUserDefined()  - This creates on OnUserDefined event. The script for handling this event
         ///                           can be set in the Scripts Tab of the Properties menu for the object/area/module.
         /// </summary>
-        public static void SignalEvent(uint oObject, NWN.Event evToRun)
+        public static void SignalEvent(uint oObject, IntPtr evToRun)
         {
-            NWN.Internal.NativeFunctions.StackPushEvent(evToRun.Handle);
+            NWN.Internal.NativeFunctions.StackPushEvent(evToRun);
             NWN.Internal.NativeFunctions.StackPushObject(oObject);
             NWN.Internal.NativeFunctions.CallBuiltIn(131);
         }
@@ -1764,11 +1767,11 @@ namespace NWN
         ///     GetUserDefinedEventNumber() to retrieve the value of nUserDefinedEventNumber
         ///     that was used when the event was signaled.
         /// </summary>
-        public static NWN.Event EventUserDefined(int nUserDefinedEventNumber)
+        public static IntPtr EventUserDefined(int nUserDefinedEventNumber)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nUserDefinedEventNumber);
             NWN.Internal.NativeFunctions.CallBuiltIn(132);
-            return new NWN.Event(NWN.Internal.NativeFunctions.StackPopEvent());
+            return NWN.Internal.NativeFunctions.StackPopEvent();
         }
 
         /// <summary>
@@ -1777,12 +1780,12 @@ namespace NWN
         ///    applied will die in an extraordinary fashion
         ///  - nDisplayFeedback
         /// </summary>
-        public static NWN.Effect EffectDeath(int nSpectacularDeath = FALSE, int nDisplayFeedback = TRUE)
+        public static IntPtr EffectDeath(int nSpectacularDeath = FALSE, int nDisplayFeedback = TRUE)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nDisplayFeedback);
             NWN.Internal.NativeFunctions.StackPushInteger(nSpectacularDeath);
             NWN.Internal.NativeFunctions.CallBuiltIn(133);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -1791,10 +1794,10 @@ namespace NWN
         ///  is removed. This should be applied as a temporary effect with a 3 second
         ///  duration minimum (1 second to fall, 1 second sitting, 1 second to get up).
         /// </summary>
-        public static NWN.Effect EffectKnockdown()
+        public static IntPtr EffectKnockdown()
         {
             NWN.Internal.NativeFunctions.CallBuiltIn(134);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -1824,9 +1827,9 @@ namespace NWN
         /// <summary>
         ///  Normalize vVector
         /// </summary>
-        public static NWN.Vector VectorNormalize(NWN.Vector? vVector)
+        public static Vector3 VectorNormalize(Vector3? vVector)
         {
-            NWN.Internal.NativeFunctions.StackPushVector(vVector.HasValue ? vVector.Value : new NWN.Vector());
+            NWN.Internal.NativeFunctions.StackPushVector(vVector.HasValue ? vVector.Value : new Vector3());
             NWN.Internal.NativeFunctions.CallBuiltIn(137);
             return NWN.Internal.NativeFunctions.StackPopVector();
         }
@@ -1840,7 +1843,7 @@ namespace NWN
         ///  - nWisMod: wisdom modifier
         ///  - nChaMod: charisma modifier
         /// </summary>
-        public static NWN.Effect EffectCurse(int nStrMod = 1, int nDexMod = 1, int nConMod = 1, int nIntMod = 1, int nWisMod = 1, int nChaMod = 1)
+        public static IntPtr EffectCurse(int nStrMod = 1, int nDexMod = 1, int nConMod = 1, int nIntMod = 1, int nWisMod = 1, int nChaMod = 1)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nChaMod);
             NWN.Internal.NativeFunctions.StackPushInteger(nWisMod);
@@ -1849,7 +1852,7 @@ namespace NWN
             NWN.Internal.NativeFunctions.StackPushInteger(nDexMod);
             NWN.Internal.NativeFunctions.StackPushInteger(nStrMod);
             NWN.Internal.NativeFunctions.CallBuiltIn(138);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -1884,17 +1887,17 @@ namespace NWN
         ///  - vVector
         ///  - bPrepend: if this is TRUE, the message will be prefixed with "PRINTVECTOR:"
         /// </summary>
-        public static void PrintVector(NWN.Vector? vVector, int bPrepend)
+        public static void PrintVector(Vector3? vVector, int bPrepend)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(bPrepend);
-            NWN.Internal.NativeFunctions.StackPushVector(vVector.HasValue ? vVector.Value : new NWN.Vector());
+            NWN.Internal.NativeFunctions.StackPushVector(vVector.HasValue ? vVector.Value : new Vector3());
             NWN.Internal.NativeFunctions.CallBuiltIn(141);
         }
 
         /// <summary>
         ///  Create a vector with the specified values for x, y and z
         /// </summary>
-        public static NWN.Vector Vector(float x = 0.0f, float y = 0.0f, float z = 0.0f)
+        public static Vector3 Vector(float x = 0.0f, float y = 0.0f, float z = 0.0f)
         {
             NWN.Internal.NativeFunctions.StackPushFloat(z);
             NWN.Internal.NativeFunctions.StackPushFloat(y);
@@ -1906,16 +1909,16 @@ namespace NWN
         /// <summary>
         ///  Cause the caller to face vTarget
         /// </summary>
-        public static void SetFacingPoint(NWN.Vector? vTarget)
+        public static void SetFacingPoint(Vector3? vTarget)
         {
-            NWN.Internal.NativeFunctions.StackPushVector(vTarget.HasValue ? vTarget.Value : new NWN.Vector());
+            NWN.Internal.NativeFunctions.StackPushVector(vTarget.HasValue ? vTarget.Value : new Vector3());
             NWN.Internal.NativeFunctions.CallBuiltIn(143);
         }
 
         /// <summary>
         ///  Convert fAngle to a vector
         /// </summary>
-        public static NWN.Vector AngleToVector(float fAngle)
+        public static Vector3 AngleToVector(float fAngle)
         {
             NWN.Internal.NativeFunctions.StackPushFloat(fAngle);
             NWN.Internal.NativeFunctions.CallBuiltIn(144);
@@ -1925,9 +1928,9 @@ namespace NWN
         /// <summary>
         ///  Convert vVector to an angle
         /// </summary>
-        public static float VectorToAngle(NWN.Vector? vVector)
+        public static float VectorToAngle(Vector3? vVector)
         {
-            NWN.Internal.NativeFunctions.StackPushVector(vVector.HasValue ? vVector.Value : new NWN.Vector());
+            NWN.Internal.NativeFunctions.StackPushVector(vVector.HasValue ? vVector.Value : new Vector3());
             NWN.Internal.NativeFunctions.CallBuiltIn(145);
             return NWN.Internal.NativeFunctions.StackPopFloat();
         }
@@ -1961,10 +1964,10 @@ namespace NWN
         /// <summary>
         ///  Create a Paralyze effect
         /// </summary>
-        public static NWN.Effect EffectParalyze()
+        public static IntPtr EffectParalyze()
         {
             NWN.Internal.NativeFunctions.CallBuiltIn(148);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -1976,20 +1979,20 @@ namespace NWN
         ///  * Returns an effect of type EFFECT_TYPE_INVALIDEFFECT if nImmunityToSpell is
         ///    invalid.
         /// </summary>
-        public static NWN.Effect EffectSpellImmunity(int nImmunityToSpell = SPELL_ALL_SPELLS)
+        public static IntPtr EffectSpellImmunity(int nImmunityToSpell = SPELL_ALL_SPELLS)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nImmunityToSpell);
             NWN.Internal.NativeFunctions.CallBuiltIn(149);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
         ///  Create a Deaf effect
         /// </summary>
-        public static NWN.Effect EffectDeaf()
+        public static IntPtr EffectDeaf()
         {
             NWN.Internal.NativeFunctions.CallBuiltIn(150);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -2007,9 +2010,9 @@ namespace NWN
         /// <summary>
         ///  Set oObject's local location variable sVarname to lValue
         /// </summary>
-        public static void SetLocalLocation(uint oObject, string sVarName, NWN.Location lValue)
+        public static void SetLocalLocation(uint oObject, string sVarName, IntPtr lValue)
         {
-            NWN.Internal.NativeFunctions.StackPushLocation(lValue.Handle);
+            NWN.Internal.NativeFunctions.StackPushLocation(lValue);
             NWN.Internal.NativeFunctions.StackPushStringUTF8(sVarName);
             NWN.Internal.NativeFunctions.StackPushObject(oObject);
             NWN.Internal.NativeFunctions.CallBuiltIn(152);
@@ -2018,21 +2021,21 @@ namespace NWN
         /// <summary>
         ///  Get oObject's local location variable sVarname
         /// </summary>
-        public static NWN.Location GetLocalLocation(uint oObject, string sVarName)
+        public static IntPtr GetLocalLocation(uint oObject, string sVarName)
         {
             NWN.Internal.NativeFunctions.StackPushStringUTF8(sVarName);
             NWN.Internal.NativeFunctions.StackPushObject(oObject);
             NWN.Internal.NativeFunctions.CallBuiltIn(153);
-            return new NWN.Location(NWN.Internal.NativeFunctions.StackPopLocation());
+            return NWN.Internal.NativeFunctions.StackPopLocation();
         }
 
         /// <summary>
         ///  Create a Sleep effect
         /// </summary>
-        public static NWN.Effect EffectSleep()
+        public static IntPtr EffectSleep()
         {
             NWN.Internal.NativeFunctions.CallBuiltIn(154);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -2053,55 +2056,55 @@ namespace NWN
         /// <summary>
         ///  Create a Charm effect
         /// </summary>
-        public static NWN.Effect EffectCharmed()
+        public static IntPtr EffectCharmed()
         {
             NWN.Internal.NativeFunctions.CallBuiltIn(156);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
         ///  Create a Confuse effect
         /// </summary>
-        public static NWN.Effect EffectConfused()
+        public static IntPtr EffectConfused()
         {
             NWN.Internal.NativeFunctions.CallBuiltIn(157);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
         ///  Create a Frighten effect
         /// </summary>
-        public static NWN.Effect EffectFrightened()
+        public static IntPtr EffectFrightened()
         {
             NWN.Internal.NativeFunctions.CallBuiltIn(158);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
         ///  Create a Dominate effect
         /// </summary>
-        public static NWN.Effect EffectDominated()
+        public static IntPtr EffectDominated()
         {
             NWN.Internal.NativeFunctions.CallBuiltIn(159);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
         ///  Create a Daze effect
         /// </summary>
-        public static NWN.Effect EffectDazed()
+        public static IntPtr EffectDazed()
         {
             NWN.Internal.NativeFunctions.CallBuiltIn(160);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
         ///  Create a Stun effect
         /// </summary>
-        public static NWN.Effect EffectStunned()
+        public static IntPtr EffectStunned()
         {
             NWN.Internal.NativeFunctions.CallBuiltIn(161);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -2129,12 +2132,12 @@ namespace NWN
         ///  - nAmount: amount of damage to be regenerated per time interval
         ///  - fIntervalSeconds: length of interval in seconds
         /// </summary>
-        public static NWN.Effect EffectRegenerate(int nAmount, float fIntervalSeconds)
+        public static IntPtr EffectRegenerate(int nAmount, float fIntervalSeconds)
         {
             NWN.Internal.NativeFunctions.StackPushFloat(fIntervalSeconds);
             NWN.Internal.NativeFunctions.StackPushInteger(nAmount);
             NWN.Internal.NativeFunctions.CallBuiltIn(164);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -2145,11 +2148,11 @@ namespace NWN
         ///    50 = 50% faster
         ///    99 = almost twice as fast
         /// </summary>
-        public static NWN.Effect EffectMovementSpeedIncrease(int nPercentChange)
+        public static IntPtr EffectMovementSpeedIncrease(int nPercentChange)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nPercentChange);
             NWN.Internal.NativeFunctions.CallBuiltIn(165);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -2208,9 +2211,9 @@ namespace NWN
         ///  Get the effect type (EFFECT_TYPE_*) of eEffect.
         ///  * Return value if eEffect is invalid: EFFECT_INVALIDEFFECT
         /// </summary>
-        public static int GetEffectType(NWN.Effect eEffect)
+        public static int GetEffectType(IntPtr eEffect)
         {
-            NWN.Internal.NativeFunctions.StackPushEffect(eEffect.Handle);
+            NWN.Internal.NativeFunctions.StackPushEffect(eEffect);
             NWN.Internal.NativeFunctions.CallBuiltIn(170);
             return NWN.Internal.NativeFunctions.StackPopInteger();
         }
@@ -2219,14 +2222,14 @@ namespace NWN
         ///  Create an Area Of Effect effect in the area of the creature it is applied to.
         ///  If the scripts are not specified, default ones will be used.
         /// </summary>
-        public static NWN.Effect EffectAreaOfEffect(int nAreaEffectId, string sOnEnterScript = "", string sHeartbeatScript = "", string sOnExitScript = "")
+        public static IntPtr EffectAreaOfEffect(int nAreaEffectId, string sOnEnterScript = "", string sHeartbeatScript = "", string sOnExitScript = "")
         {
             NWN.Internal.NativeFunctions.StackPushStringUTF8(sOnExitScript);
             NWN.Internal.NativeFunctions.StackPushStringUTF8(sHeartbeatScript);
             NWN.Internal.NativeFunctions.StackPushStringUTF8(sOnEnterScript);
             NWN.Internal.NativeFunctions.StackPushInteger(nAreaEffectId);
             NWN.Internal.NativeFunctions.CallBuiltIn(171);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -2322,12 +2325,12 @@ namespace NWN
         ///  - nMissEffect: if this is TRUE, a random vector near or past the target will
         ///    be generated, on which to play the effect
         /// </summary>
-        public static NWN.Effect EffectVisualEffect(int nVisualEffectId, int nMissEffect = FALSE)
+        public static IntPtr EffectVisualEffect(int nVisualEffectId, int nMissEffect = FALSE)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nMissEffect);
             NWN.Internal.NativeFunctions.StackPushInteger(nVisualEffectId);
             NWN.Internal.NativeFunctions.CallBuiltIn(180);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -2566,12 +2569,12 @@ namespace NWN
         ///  determining if an effect will be removed or not and as such should never be
         ///  packaged *only* with other visual effects in a link.
         /// </summary>
-        public static NWN.Effect EffectLinkEffects(NWN.Effect eChildEffect, NWN.Effect eParentEffect)
+        public static IntPtr EffectLinkEffects(IntPtr eChildEffect, IntPtr eParentEffect)
         {
-            NWN.Internal.NativeFunctions.StackPushEffect(eParentEffect.Handle);
-            NWN.Internal.NativeFunctions.StackPushEffect(eChildEffect.Handle);
+            NWN.Internal.NativeFunctions.StackPushEffect(eParentEffect);
+            NWN.Internal.NativeFunctions.StackPushEffect(eChildEffect);
             NWN.Internal.NativeFunctions.CallBuiltIn(199);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -2694,14 +2697,14 @@ namespace NWN
         ///  * Returns an effect of type EFFECT_TYPE_INVALIDEFFECT if nBeamVisualEffect is
         ///    not valid.
         /// </summary>
-        public static NWN.Effect EffectBeam(int nBeamVisualEffect, uint oEffector, int nBodyPart, int bMissEffect = FALSE)
+        public static IntPtr EffectBeam(int nBeamVisualEffect, uint oEffector, int nBodyPart, int bMissEffect = FALSE)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(bMissEffect);
             NWN.Internal.NativeFunctions.StackPushInteger(nBodyPart);
             NWN.Internal.NativeFunctions.StackPushObject(oEffector);
             NWN.Internal.NativeFunctions.StackPushInteger(nBeamVisualEffect);
             NWN.Internal.NativeFunctions.CallBuiltIn(207);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -2773,53 +2776,53 @@ namespace NWN
         ///  Create a Spell Resistance Increase effect.
         ///  - nValue: size of spell resistance increase
         /// </summary>
-        public static NWN.Effect EffectSpellResistanceIncrease(int nValue)
+        public static IntPtr EffectSpellResistanceIncrease(int nValue)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nValue);
             NWN.Internal.NativeFunctions.CallBuiltIn(212);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
         ///  Get the location of oObject.
         /// </summary>
-        public static NWN.Location GetLocation(uint oObject)
+        public static IntPtr GetLocation(uint oObject)
         {
             NWN.Internal.NativeFunctions.StackPushObject(oObject);
             NWN.Internal.NativeFunctions.CallBuiltIn(213);
-            return new NWN.Location(NWN.Internal.NativeFunctions.StackPopLocation());
+            return NWN.Internal.NativeFunctions.StackPopLocation();
         }
 
         /// <summary>
         ///  The subject will jump to lLocation instantly (even between areas).
         ///  If lLocation is invalid, nothing will happen.
         /// </summary>
-        public static void ActionJumpToLocation(NWN.Location lLocation)
+        public static void ActionJumpToLocation(IntPtr lLocation)
         {
-            NWN.Internal.NativeFunctions.StackPushLocation(lLocation.Handle);
+            NWN.Internal.NativeFunctions.StackPushLocation(lLocation);
             NWN.Internal.NativeFunctions.CallBuiltIn(214);
         }
 
         /// <summary>
         ///  Create a location.
         /// </summary>
-        public static NWN.Location Location(uint oArea, NWN.Vector? vPosition, float fOrientation)
+        public static IntPtr Location(uint oArea, Vector3? vPosition, float fOrientation)
         {
             NWN.Internal.NativeFunctions.StackPushFloat(fOrientation);
-            NWN.Internal.NativeFunctions.StackPushVector(vPosition.HasValue ? vPosition.Value : new NWN.Vector());
+            NWN.Internal.NativeFunctions.StackPushVector(vPosition.HasValue ? vPosition.Value : new Vector3());
             NWN.Internal.NativeFunctions.StackPushObject(oArea);
             NWN.Internal.NativeFunctions.CallBuiltIn(215);
-            return new NWN.Location(NWN.Internal.NativeFunctions.StackPopLocation());
+            return NWN.Internal.NativeFunctions.StackPopLocation();
         }
 
         /// <summary>
         ///  Apply eEffect at lLocation.
         /// </summary>
-        public static void ApplyEffectAtLocation(int nDurationType, NWN.Effect eEffect, NWN.Location lLocation, float fDuration = 0.0f)
+        public static void ApplyEffectAtLocation(int nDurationType, IntPtr eEffect, IntPtr lLocation, float fDuration = 0.0f)
         {
             NWN.Internal.NativeFunctions.StackPushFloat(fDuration);
-            NWN.Internal.NativeFunctions.StackPushLocation(lLocation.Handle);
-            NWN.Internal.NativeFunctions.StackPushEffect(eEffect.Handle);
+            NWN.Internal.NativeFunctions.StackPushLocation(lLocation);
+            NWN.Internal.NativeFunctions.StackPushEffect(eEffect);
             NWN.Internal.NativeFunctions.StackPushInteger(nDurationType);
             NWN.Internal.NativeFunctions.CallBuiltIn(216);
         }
@@ -2857,11 +2860,11 @@ namespace NWN
         /// <summary>
         ///  Apply eEffect to oTarget.
         /// </summary>
-        public static void ApplyEffectToObject(int nDurationType, NWN.Effect eEffect, uint oTarget, float fDuration = 0.0f)
+        public static void ApplyEffectToObject(int nDurationType, IntPtr eEffect, uint oTarget, float fDuration = 0.0f)
         {
             NWN.Internal.NativeFunctions.StackPushFloat(fDuration);
             NWN.Internal.NativeFunctions.StackPushObject(oTarget);
-            NWN.Internal.NativeFunctions.StackPushEffect(eEffect.Handle);
+            NWN.Internal.NativeFunctions.StackPushEffect(eEffect);
             NWN.Internal.NativeFunctions.StackPushInteger(nDurationType);
             NWN.Internal.NativeFunctions.CallBuiltIn(220);
         }
@@ -2882,18 +2885,18 @@ namespace NWN
         /// <summary>
         ///  Get the location of the caller's last spell target.
         /// </summary>
-        public static NWN.Location GetSpellTargetLocation()
+        public static IntPtr GetSpellTargetLocation()
         {
             NWN.Internal.NativeFunctions.CallBuiltIn(222);
-            return new NWN.Location(NWN.Internal.NativeFunctions.StackPopLocation());
+            return NWN.Internal.NativeFunctions.StackPopLocation();
         }
 
         /// <summary>
         ///  Get the position vector from lLocation.
         /// </summary>
-        public static NWN.Vector GetPositionFromLocation(NWN.Location lLocation)
+        public static Vector3 GetPositionFromLocation(IntPtr lLocation)
         {
-            NWN.Internal.NativeFunctions.StackPushLocation(lLocation.Handle);
+            NWN.Internal.NativeFunctions.StackPushLocation(lLocation);
             NWN.Internal.NativeFunctions.CallBuiltIn(223);
             return NWN.Internal.NativeFunctions.StackPopVector();
         }
@@ -2901,9 +2904,9 @@ namespace NWN
         /// <summary>
         ///  Get the area's object ID from lLocation.
         /// </summary>
-        public static uint GetAreaFromLocation(NWN.Location lLocation)
+        public static uint GetAreaFromLocation(IntPtr lLocation)
         {
-            NWN.Internal.NativeFunctions.StackPushLocation(lLocation.Handle);
+            NWN.Internal.NativeFunctions.StackPushLocation(lLocation);
             NWN.Internal.NativeFunctions.CallBuiltIn(224);
             return NWN.Internal.NativeFunctions.StackPopObject();
         }
@@ -2911,9 +2914,9 @@ namespace NWN
         /// <summary>
         ///  Get the orientation value from lLocation.
         /// </summary>
-        public static float GetFacingFromLocation(NWN.Location lLocation)
+        public static float GetFacingFromLocation(IntPtr lLocation)
         {
-            NWN.Internal.NativeFunctions.StackPushLocation(lLocation.Handle);
+            NWN.Internal.NativeFunctions.StackPushLocation(lLocation);
             NWN.Internal.NativeFunctions.CallBuiltIn(225);
             return NWN.Internal.NativeFunctions.StackPopFloat();
         }
@@ -2946,14 +2949,14 @@ namespace NWN
         ///    further specify the type of creature that we are looking for.
         ///  * Return value on error: OBJECT_INVALID
         /// </summary>
-        public static uint GetNearestCreatureToLocation(int nFirstCriteriaType, int nFirstCriteriaValue, NWN.Location lLocation, int nNth = 1, int nSecondCriteriaType = -1, int nSecondCriteriaValue = -1, int nThirdCriteriaType = -1, int nThirdCriteriaValue = -1)
+        public static uint GetNearestCreatureToLocation(int nFirstCriteriaType, int nFirstCriteriaValue, IntPtr lLocation, int nNth = 1, int nSecondCriteriaType = -1, int nSecondCriteriaValue = -1, int nThirdCriteriaType = -1, int nThirdCriteriaValue = -1)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nThirdCriteriaValue);
             NWN.Internal.NativeFunctions.StackPushInteger(nThirdCriteriaType);
             NWN.Internal.NativeFunctions.StackPushInteger(nSecondCriteriaValue);
             NWN.Internal.NativeFunctions.StackPushInteger(nSecondCriteriaType);
             NWN.Internal.NativeFunctions.StackPushInteger(nNth);
-            NWN.Internal.NativeFunctions.StackPushLocation(lLocation.Handle);
+            NWN.Internal.NativeFunctions.StackPushLocation(lLocation);
             NWN.Internal.NativeFunctions.StackPushInteger(nFirstCriteriaValue);
             NWN.Internal.NativeFunctions.StackPushInteger(nFirstCriteriaType);
             NWN.Internal.NativeFunctions.CallBuiltIn(226);
@@ -2983,10 +2986,10 @@ namespace NWN
         ///  - nNth
         ///  * Return value on error: OBJECT_INVALID
         /// </summary>
-        public static uint GetNearestObjectToLocation(int nObjectType, NWN.Location lLocation, int nNth = 1)
+        public static uint GetNearestObjectToLocation(int nObjectType, IntPtr lLocation, int nNth = 1)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nNth);
-            NWN.Internal.NativeFunctions.StackPushLocation(lLocation.Handle);
+            NWN.Internal.NativeFunctions.StackPushLocation(lLocation);
             NWN.Internal.NativeFunctions.StackPushInteger(nObjectType);
             NWN.Internal.NativeFunctions.CallBuiltIn(228);
             return NWN.Internal.NativeFunctions.StackPopObject();
@@ -3057,13 +3060,13 @@ namespace NWN
         ///    the end-user to simulate
         ///    a high-level magic user having lots of advance warning of impending trouble.
         /// </summary>
-        public static void ActionCastSpellAtLocation(int nSpell, NWN.Location lTargetLocation, int nMetaMagic = METAMAGIC_ANY, int bCheat = FALSE, int nProjectilePathType = PROJECTILE_PATH_TYPE_DEFAULT, int bInstantSpell = FALSE)
+        public static void ActionCastSpellAtLocation(int nSpell, IntPtr lTargetLocation, int nMetaMagic = METAMAGIC_ANY, int bCheat = FALSE, int nProjectilePathType = PROJECTILE_PATH_TYPE_DEFAULT, int bInstantSpell = FALSE)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(bInstantSpell);
             NWN.Internal.NativeFunctions.StackPushInteger(nProjectilePathType);
             NWN.Internal.NativeFunctions.StackPushInteger(bCheat);
             NWN.Internal.NativeFunctions.StackPushInteger(nMetaMagic);
-            NWN.Internal.NativeFunctions.StackPushLocation(lTargetLocation.Handle);
+            NWN.Internal.NativeFunctions.StackPushLocation(lTargetLocation);
             NWN.Internal.NativeFunctions.StackPushInteger(nSpell);
             NWN.Internal.NativeFunctions.CallBuiltIn(234);
         }
@@ -3164,11 +3167,11 @@ namespace NWN
         ///  - bUseAppearAnimation
         ///  - sNewTag - if this string is not empty, it will replace the default tag from the template
         /// </summary>
-        public static uint CreateObject(int nObjectType, string sTemplate, NWN.Location lLocation, int bUseAppearAnimation = FALSE, string sNewTag = "")
+        public static uint CreateObject(int nObjectType, string sTemplate, IntPtr lLocation, int bUseAppearAnimation = FALSE, string sNewTag = "")
         {
             NWN.Internal.NativeFunctions.StackPushStringUTF8(sNewTag);
             NWN.Internal.NativeFunctions.StackPushInteger(bUseAppearAnimation);
-            NWN.Internal.NativeFunctions.StackPushLocation(lLocation.Handle);
+            NWN.Internal.NativeFunctions.StackPushLocation(lLocation);
             NWN.Internal.NativeFunctions.StackPushStringUTF8(sTemplate);
             NWN.Internal.NativeFunctions.StackPushInteger(nObjectType);
             NWN.Internal.NativeFunctions.CallBuiltIn(243);
@@ -3192,13 +3195,13 @@ namespace NWN
         ///      GetLastSpell() to get the type of spell cast (nSpell)
         ///      GetLastSpellHarmful() to determine if the spell cast at the object was harmful.
         /// </summary>
-        public static NWN.Event EventSpellCastAt(uint oCaster, int nSpell, int bHarmful = TRUE)
+        public static IntPtr EventSpellCastAt(uint oCaster, int nSpell, int bHarmful = TRUE)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(bHarmful);
             NWN.Internal.NativeFunctions.StackPushInteger(nSpell);
             NWN.Internal.NativeFunctions.StackPushObject(oCaster);
             NWN.Internal.NativeFunctions.CallBuiltIn(244);
-            return new NWN.Event(NWN.Internal.NativeFunctions.StackPopEvent());
+            return NWN.Internal.NativeFunctions.StackPopEvent();
         }
 
         /// <summary>
@@ -3256,31 +3259,31 @@ namespace NWN
         ///  Create a Poison effect.
         ///  - nPoisonType: POISON_*
         /// </summary>
-        public static NWN.Effect EffectPoison(int nPoisonType)
+        public static IntPtr EffectPoison(int nPoisonType)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nPoisonType);
             NWN.Internal.NativeFunctions.CallBuiltIn(250);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
         ///  Create a Disease effect.
         ///  - nDiseaseType: DISEASE_*
         /// </summary>
-        public static NWN.Effect EffectDisease(int nDiseaseType)
+        public static IntPtr EffectDisease(int nDiseaseType)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nDiseaseType);
             NWN.Internal.NativeFunctions.CallBuiltIn(251);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
         ///  Create a Silence effect.
         /// </summary>
-        public static NWN.Effect EffectSilence()
+        public static IntPtr EffectSilence()
         {
             NWN.Internal.NativeFunctions.CallBuiltIn(252);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -3483,19 +3486,19 @@ namespace NWN
         /// <summary>
         ///  Create a Haste effect.
         /// </summary>
-        public static NWN.Effect EffectHaste()
+        public static IntPtr EffectHaste()
         {
             NWN.Internal.NativeFunctions.CallBuiltIn(270);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
         ///  Create a Slow effect.
         /// </summary>
-        public static NWN.Effect EffectSlow()
+        public static IntPtr EffectSlow()
         {
             NWN.Internal.NativeFunctions.CallBuiltIn(271);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -3512,11 +3515,11 @@ namespace NWN
         ///  Create an Immunity effect.
         ///  - nImmunityType: IMMUNITY_TYPE_*
         /// </summary>
-        public static NWN.Effect EffectImmunity(int nImmunityType)
+        public static IntPtr EffectImmunity(int nImmunityType)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nImmunityType);
             NWN.Internal.NativeFunctions.CallBuiltIn(273);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -3540,12 +3543,12 @@ namespace NWN
         ///  - nDamageType: DAMAGE_TYPE_*
         ///  - nPercentImmunity
         /// </summary>
-        public static NWN.Effect EffectDamageImmunityIncrease(int nDamageType, int nPercentImmunity)
+        public static IntPtr EffectDamageImmunityIncrease(int nDamageType, int nPercentImmunity)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nPercentImmunity);
             NWN.Internal.NativeFunctions.StackPushInteger(nDamageType);
             NWN.Internal.NativeFunctions.CallBuiltIn(275);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -3763,10 +3766,10 @@ namespace NWN
         ///  To specify the OnConversation script that should run, view the Creature Properties on
         ///  the creature and click on the Scripts Tab. Then specify a script for the OnConversation event.
         /// </summary>
-        public static NWN.Event EventConversation()
+        public static IntPtr EventConversation()
         {
             NWN.Internal.NativeFunctions.CallBuiltIn(295);
-            return new NWN.Event(NWN.Internal.NativeFunctions.StackPopEvent());
+            return NWN.Internal.NativeFunctions.StackPopEvent();
         }
 
         /// <summary>
@@ -3794,10 +3797,10 @@ namespace NWN
         /// <summary>
         ///  Get the distance between lLocationA and lLocationB.
         /// </summary>
-        public static float GetDistanceBetweenLocations(NWN.Location lLocationA, NWN.Location lLocationB)
+        public static float GetDistanceBetweenLocations(IntPtr lLocationA, IntPtr lLocationB)
         {
-            NWN.Internal.NativeFunctions.StackPushLocation(lLocationB.Handle);
-            NWN.Internal.NativeFunctions.StackPushLocation(lLocationA.Handle);
+            NWN.Internal.NativeFunctions.StackPushLocation(lLocationB);
+            NWN.Internal.NativeFunctions.StackPushLocation(lLocationA);
             NWN.Internal.NativeFunctions.CallBuiltIn(298);
             return NWN.Internal.NativeFunctions.StackPopFloat();
         }
@@ -3840,33 +3843,33 @@ namespace NWN
         ///  Create a Spell Talent.
         ///  - nSpell: SPELL_*
         /// </summary>
-        public static NWN.Talent TalentSpell(int nSpell)
+        public static IntPtr TalentSpell(int nSpell)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nSpell);
             NWN.Internal.NativeFunctions.CallBuiltIn(301);
-            return new NWN.Talent(NWN.Internal.NativeFunctions.StackPopTalent());
+            return NWN.Internal.NativeFunctions.StackPopTalent();
         }
 
         /// <summary>
         ///  Create a Feat Talent.
         ///  - nFeat: FEAT_*
         /// </summary>
-        public static NWN.Talent TalentFeat(int nFeat)
+        public static IntPtr TalentFeat(int nFeat)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nFeat);
             NWN.Internal.NativeFunctions.CallBuiltIn(302);
-            return new NWN.Talent(NWN.Internal.NativeFunctions.StackPopTalent());
+            return NWN.Internal.NativeFunctions.StackPopTalent();
         }
 
         /// <summary>
         ///  Create a Skill Talent.
         ///  - nSkill: SKILL_*
         /// </summary>
-        public static NWN.Talent TalentSkill(int nSkill)
+        public static IntPtr TalentSkill(int nSkill)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nSkill);
             NWN.Internal.NativeFunctions.CallBuiltIn(303);
-            return new NWN.Talent(NWN.Internal.NativeFunctions.StackPopTalent());
+            return NWN.Internal.NativeFunctions.StackPopTalent();
         }
 
         /// <summary>
@@ -3889,9 +3892,9 @@ namespace NWN
         ///  Get the spell (SPELL_*) that applied eSpellEffect.
         ///  * Returns -1 if eSpellEffect was applied outside a spell script.
         /// </summary>
-        public static int GetEffectSpellId(NWN.Effect eSpellEffect)
+        public static int GetEffectSpellId(IntPtr eSpellEffect)
         {
-            NWN.Internal.NativeFunctions.StackPushEffect(eSpellEffect.Handle);
+            NWN.Internal.NativeFunctions.StackPushEffect(eSpellEffect);
             NWN.Internal.NativeFunctions.CallBuiltIn(305);
             return NWN.Internal.NativeFunctions.StackPopInteger();
         }
@@ -3899,10 +3902,10 @@ namespace NWN
         /// <summary>
         ///  Determine whether oCreature has tTalent.
         /// </summary>
-        public static int GetCreatureHasTalent(NWN.Talent tTalent, uint oCreature = OBJECT_INVALID)
+        public static int GetCreatureHasTalent(IntPtr tTalent, uint oCreature = OBJECT_INVALID)
         {
             NWN.Internal.NativeFunctions.StackPushObject(oCreature);
-            NWN.Internal.NativeFunctions.StackPushTalent(tTalent.Handle);
+            NWN.Internal.NativeFunctions.StackPushTalent(tTalent);
             NWN.Internal.NativeFunctions.CallBuiltIn(306);
             return NWN.Internal.NativeFunctions.StackPopInteger();
         }
@@ -3912,12 +3915,12 @@ namespace NWN
         ///  - nCategory: TALENT_CATEGORY_*
         ///  - oCreature
         /// </summary>
-        public static NWN.Talent GetCreatureTalentRandom(int nCategory, uint oCreature = OBJECT_INVALID)
+        public static IntPtr GetCreatureTalentRandom(int nCategory, uint oCreature = OBJECT_INVALID)
         {
             NWN.Internal.NativeFunctions.StackPushObject(oCreature);
             NWN.Internal.NativeFunctions.StackPushInteger(nCategory);
             NWN.Internal.NativeFunctions.CallBuiltIn(307);
-            return new NWN.Talent(NWN.Internal.NativeFunctions.StackPopTalent());
+            return NWN.Internal.NativeFunctions.StackPopTalent();
         }
 
         /// <summary>
@@ -3927,32 +3930,32 @@ namespace NWN
         ///  - nCRMax: Challenge Rating of the talent
         ///  - oCreature
         /// </summary>
-        public static NWN.Talent GetCreatureTalentBest(int nCategory, int nCRMax, uint oCreature = OBJECT_INVALID)
+        public static IntPtr GetCreatureTalentBest(int nCategory, int nCRMax, uint oCreature = OBJECT_INVALID)
         {
             NWN.Internal.NativeFunctions.StackPushObject(oCreature);
             NWN.Internal.NativeFunctions.StackPushInteger(nCRMax);
             NWN.Internal.NativeFunctions.StackPushInteger(nCategory);
             NWN.Internal.NativeFunctions.CallBuiltIn(308);
-            return new NWN.Talent(NWN.Internal.NativeFunctions.StackPopTalent());
+            return NWN.Internal.NativeFunctions.StackPopTalent();
         }
 
         /// <summary>
         ///  Use tChosenTalent on oTarget.
         /// </summary>
-        public static void ActionUseTalentOnObject(NWN.Talent tChosenTalent, uint oTarget)
+        public static void ActionUseTalentOnObject(IntPtr tChosenTalent, uint oTarget)
         {
             NWN.Internal.NativeFunctions.StackPushObject(oTarget);
-            NWN.Internal.NativeFunctions.StackPushTalent(tChosenTalent.Handle);
+            NWN.Internal.NativeFunctions.StackPushTalent(tChosenTalent);
             NWN.Internal.NativeFunctions.CallBuiltIn(309);
         }
 
         /// <summary>
         ///  Use tChosenTalent at lTargetLocation.
         /// </summary>
-        public static void ActionUseTalentAtLocation(NWN.Talent tChosenTalent, NWN.Location lTargetLocation)
+        public static void ActionUseTalentAtLocation(IntPtr tChosenTalent, IntPtr lTargetLocation)
         {
-            NWN.Internal.NativeFunctions.StackPushLocation(lTargetLocation.Handle);
-            NWN.Internal.NativeFunctions.StackPushTalent(tChosenTalent.Handle);
+            NWN.Internal.NativeFunctions.StackPushLocation(lTargetLocation);
+            NWN.Internal.NativeFunctions.StackPushTalent(tChosenTalent);
             NWN.Internal.NativeFunctions.CallBuiltIn(310);
         }
 
@@ -3980,9 +3983,9 @@ namespace NWN
         /// <summary>
         ///  Jump to lDestination.  The action is added to the TOP of the action queue.
         /// </summary>
-        public static void JumpToLocation(NWN.Location lDestination)
+        public static void JumpToLocation(IntPtr lDestination)
         {
-            NWN.Internal.NativeFunctions.StackPushLocation(lDestination.Handle);
+            NWN.Internal.NativeFunctions.StackPushLocation(lDestination);
             NWN.Internal.NativeFunctions.CallBuiltIn(313);
         }
 
@@ -3991,11 +3994,11 @@ namespace NWN
         ///  - nHitPoints: a positive integer
         ///  * Returns an effect of type EFFECT_TYPE_INVALIDEFFECT if nHitPoints < 0.
         /// </summary>
-        public static NWN.Effect EffectTemporaryHitpoints(int nHitPoints)
+        public static IntPtr EffectTemporaryHitpoints(int nHitPoints)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nHitPoints);
             NWN.Internal.NativeFunctions.CallBuiltIn(314);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -4413,12 +4416,12 @@ namespace NWN
         ///  - nValue
         ///  * Returns an effect of type EFFECT_TYPE_INVALIDEFFECT if nSkill is invalid.
         /// </summary>
-        public static NWN.Effect EffectSkillIncrease(int nSkill, int nValue)
+        public static IntPtr EffectSkillIncrease(int nSkill, int nValue)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nValue);
             NWN.Internal.NativeFunctions.StackPushInteger(nSkill);
             NWN.Internal.NativeFunctions.CallBuiltIn(351);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -4461,13 +4464,13 @@ namespace NWN
         ///  - nLawChaos: ALIGNMENT_LAWFUL/ALIGNMENT_CHAOTIC/ALIGNMENT_ALL
         ///  - nGoodEvil: ALIGNMENT_GOOD/ALIGNMENT_EVIL/ALIGNMENT_ALL
         /// </summary>
-        public static NWN.Effect VersusAlignmentEffect(NWN.Effect eEffect, int nLawChaos = ALIGNMENT_ALL, int nGoodEvil = ALIGNMENT_ALL)
+        public static IntPtr VersusAlignmentEffect(IntPtr eEffect, int nLawChaos = ALIGNMENT_ALL, int nGoodEvil = ALIGNMENT_ALL)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nGoodEvil);
             NWN.Internal.NativeFunctions.StackPushInteger(nLawChaos);
-            NWN.Internal.NativeFunctions.StackPushEffect(eEffect.Handle);
+            NWN.Internal.NativeFunctions.StackPushEffect(eEffect);
             NWN.Internal.NativeFunctions.CallBuiltIn(355);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -4475,22 +4478,22 @@ namespace NWN
         ///  - eEffect
         ///  - nRacialType: RACIAL_TYPE_*
         /// </summary>
-        public static NWN.Effect VersusRacialTypeEffect(NWN.Effect eEffect, int nRacialType)
+        public static IntPtr VersusRacialTypeEffect(IntPtr eEffect, int nRacialType)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nRacialType);
-            NWN.Internal.NativeFunctions.StackPushEffect(eEffect.Handle);
+            NWN.Internal.NativeFunctions.StackPushEffect(eEffect);
             NWN.Internal.NativeFunctions.CallBuiltIn(356);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
         ///  Set eEffect to be versus traps.
         /// </summary>
-        public static NWN.Effect VersusTrapEffect(NWN.Effect eEffect)
+        public static IntPtr VersusTrapEffect(IntPtr eEffect)
         {
-            NWN.Internal.NativeFunctions.StackPushEffect(eEffect.Handle);
+            NWN.Internal.NativeFunctions.StackPushEffect(eEffect);
             NWN.Internal.NativeFunctions.CallBuiltIn(357);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -4506,9 +4509,9 @@ namespace NWN
         /// <summary>
         ///  * Returns TRUE if tTalent is valid.
         /// </summary>
-        public static int GetIsTalentValid(NWN.Talent tTalent)
+        public static int GetIsTalentValid(IntPtr tTalent)
         {
-            NWN.Internal.NativeFunctions.StackPushTalent(tTalent.Handle);
+            NWN.Internal.NativeFunctions.StackPushTalent(tTalent);
             NWN.Internal.NativeFunctions.CallBuiltIn(359);
             return NWN.Internal.NativeFunctions.StackPopInteger();
         }
@@ -4516,11 +4519,11 @@ namespace NWN
         /// <summary>
         ///  Causes the action subject to move away from lMoveAwayFrom.
         /// </summary>
-        public static void ActionMoveAwayFromLocation(NWN.Location lMoveAwayFrom, int bRun = FALSE, float fMoveAwayRange = 40.0f)
+        public static void ActionMoveAwayFromLocation(IntPtr lMoveAwayFrom, int bRun = FALSE, float fMoveAwayRange = 40.0f)
         {
             NWN.Internal.NativeFunctions.StackPushFloat(fMoveAwayRange);
             NWN.Internal.NativeFunctions.StackPushInteger(bRun);
-            NWN.Internal.NativeFunctions.StackPushLocation(lMoveAwayFrom.Handle);
+            NWN.Internal.NativeFunctions.StackPushLocation(lMoveAwayFrom);
             NWN.Internal.NativeFunctions.CallBuiltIn(360);
         }
 
@@ -4539,9 +4542,9 @@ namespace NWN
         /// <summary>
         ///  Get the type (TALENT_TYPE_*) of tTalent.
         /// </summary>
-        public static int GetTypeFromTalent(NWN.Talent tTalent)
+        public static int GetTypeFromTalent(IntPtr tTalent)
         {
-            NWN.Internal.NativeFunctions.StackPushTalent(tTalent.Handle);
+            NWN.Internal.NativeFunctions.StackPushTalent(tTalent);
             NWN.Internal.NativeFunctions.CallBuiltIn(362);
             return NWN.Internal.NativeFunctions.StackPopInteger();
         }
@@ -4549,9 +4552,9 @@ namespace NWN
         /// <summary>
         ///  Get the ID of tTalent.  This could be a SPELL_*, FEAT_* or SKILL_*.
         /// </summary>
-        public static int GetIdFromTalent(NWN.Talent tTalent)
+        public static int GetIdFromTalent(IntPtr tTalent)
         {
-            NWN.Internal.NativeFunctions.StackPushTalent(tTalent.Handle);
+            NWN.Internal.NativeFunctions.StackPushTalent(tTalent);
             NWN.Internal.NativeFunctions.CallBuiltIn(363);
             return NWN.Internal.NativeFunctions.StackPopInteger();
         }
@@ -4751,10 +4754,10 @@ namespace NWN
         ///  Create a Turned effect.
         ///  Turned effects are supernatural by default.
         /// </summary>
-        public static NWN.Effect EffectTurned()
+        public static IntPtr EffectTurned()
         {
             NWN.Internal.NativeFunctions.CallBuiltIn(379);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -4786,11 +4789,11 @@ namespace NWN
         /// <summary>
         ///  Force the action subject to move to lDestination.
         /// </summary>
-        public static void ActionForceMoveToLocation(NWN.Location lDestination, int bRun = FALSE, float fTimeout = 30.0f)
+        public static void ActionForceMoveToLocation(IntPtr lDestination, int bRun = FALSE, float fTimeout = 30.0f)
         {
             NWN.Internal.NativeFunctions.StackPushFloat(fTimeout);
             NWN.Internal.NativeFunctions.StackPushInteger(bRun);
-            NWN.Internal.NativeFunctions.StackPushLocation(lDestination.Handle);
+            NWN.Internal.NativeFunctions.StackPushLocation(lDestination);
             NWN.Internal.NativeFunctions.CallBuiltIn(382);
         }
 
@@ -4843,11 +4846,11 @@ namespace NWN
         ///  - fHitPointChangePerRound: this can be positive or negative, but not zero.
         ///  * Returns an effect of type EFFECT_TYPE_INVALIDEFFECT if fHitPointChangePerRound is 0.
         /// </summary>
-        public static NWN.Effect EffectHitPointChangeWhenDying(float fHitPointChangePerRound)
+        public static IntPtr EffectHitPointChangeWhenDying(float fHitPointChangePerRound)
         {
             NWN.Internal.NativeFunctions.StackPushFloat(fHitPointChangePerRound);
             NWN.Internal.NativeFunctions.CallBuiltIn(387);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -5145,10 +5148,10 @@ namespace NWN
         /// <summary>
         ///  Get the starting location of the module.
         /// </summary>
-        public static NWN.Location GetStartingLocation()
+        public static IntPtr GetStartingLocation()
         {
             NWN.Internal.NativeFunctions.CallBuiltIn(411);
-            return new NWN.Location(NWN.Internal.NativeFunctions.StackPopLocation());
+            return NWN.Internal.NativeFunctions.StackPopLocation();
         }
 
         /// <summary>
@@ -5196,9 +5199,9 @@ namespace NWN
         /// <summary>
         ///  Set the position of oSound.
         /// </summary>
-        public static void SoundObjectSetPosition(uint oSound, NWN.Vector? vPosition)
+        public static void SoundObjectSetPosition(uint oSound, Vector3? vPosition)
         {
-            NWN.Internal.NativeFunctions.StackPushVector(vPosition.HasValue ? vPosition.Value : new NWN.Vector());
+            NWN.Internal.NativeFunctions.StackPushVector(vPosition.HasValue ? vPosition.Value : new Vector3());
             NWN.Internal.NativeFunctions.StackPushObject(oSound);
             NWN.Internal.NativeFunctions.CallBuiltIn(416);
         }
@@ -5285,13 +5288,13 @@ namespace NWN
         /// <summary>
         ///  Activate oItem.
         /// </summary>
-        public static NWN.Event EventActivateItem(uint oItem, NWN.Location lTarget, uint oTarget = OBJECT_INVALID)
+        public static IntPtr EventActivateItem(uint oItem, IntPtr lTarget, uint oTarget = OBJECT_INVALID)
         {
             NWN.Internal.NativeFunctions.StackPushObject(oTarget);
-            NWN.Internal.NativeFunctions.StackPushLocation(lTarget.Handle);
+            NWN.Internal.NativeFunctions.StackPushLocation(lTarget);
             NWN.Internal.NativeFunctions.StackPushObject(oItem);
             NWN.Internal.NativeFunctions.CallBuiltIn(424);
-            return new NWN.Event(NWN.Internal.NativeFunctions.StackPopEvent());
+            return NWN.Internal.NativeFunctions.StackPopEvent();
         }
 
         /// <summary>
@@ -5461,10 +5464,10 @@ namespace NWN
         ///  Use this in an OnItemActivated module script to get the location of the item's
         ///  target.
         /// </summary>
-        public static NWN.Location GetItemActivatedTargetLocation()
+        public static IntPtr GetItemActivatedTargetLocation()
         {
             NWN.Internal.NativeFunctions.CallBuiltIn(441);
-            return new NWN.Location(NWN.Internal.NativeFunctions.StackPopLocation());
+            return NWN.Internal.NativeFunctions.StackPopLocation();
         }
 
         /// <summary>
@@ -5516,12 +5519,12 @@ namespace NWN
         ///  - nAbility: ABILITY_*
         ///  - nModifyBy: This is the amount by which to decrement the ability
         /// </summary>
-        public static NWN.Effect EffectAbilityDecrease(int nAbility, int nModifyBy)
+        public static IntPtr EffectAbilityDecrease(int nAbility, int nModifyBy)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nModifyBy);
             NWN.Internal.NativeFunctions.StackPushInteger(nAbility);
             NWN.Internal.NativeFunctions.CallBuiltIn(446);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -5529,12 +5532,12 @@ namespace NWN
         ///  - nPenalty
         ///  - nModifierType: ATTACK_BONUS_*
         /// </summary>
-        public static NWN.Effect EffectAttackDecrease(int nPenalty, int nModifierType = ATTACK_BONUS_MISC)
+        public static IntPtr EffectAttackDecrease(int nPenalty, int nModifierType = ATTACK_BONUS_MISC)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nModifierType);
             NWN.Internal.NativeFunctions.StackPushInteger(nPenalty);
             NWN.Internal.NativeFunctions.CallBuiltIn(447);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -5542,12 +5545,12 @@ namespace NWN
         ///  - nPenalty
         ///  - nDamageType: DAMAGE_TYPE_*
         /// </summary>
-        public static NWN.Effect EffectDamageDecrease(int nPenalty, int nDamageType = DAMAGE_TYPE_MAGICAL)
+        public static IntPtr EffectDamageDecrease(int nPenalty, int nDamageType = DAMAGE_TYPE_MAGICAL)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nDamageType);
             NWN.Internal.NativeFunctions.StackPushInteger(nPenalty);
             NWN.Internal.NativeFunctions.CallBuiltIn(448);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -5555,12 +5558,12 @@ namespace NWN
         ///  - nDamageType: DAMAGE_TYPE_*
         ///  - nPercentImmunity
         /// </summary>
-        public static NWN.Effect EffectDamageImmunityDecrease(int nDamageType, int nPercentImmunity)
+        public static IntPtr EffectDamageImmunityDecrease(int nDamageType, int nPercentImmunity)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nPercentImmunity);
             NWN.Internal.NativeFunctions.StackPushInteger(nDamageType);
             NWN.Internal.NativeFunctions.CallBuiltIn(449);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -5570,13 +5573,13 @@ namespace NWN
         ///  - nDamageType: DAMAGE_TYPE_*
         ///    * Default value for nDamageType should only ever be used in this function prototype.
         /// </summary>
-        public static NWN.Effect EffectACDecrease(int nValue, int nModifyType = AC_DODGE_BONUS, int nDamageType = AC_VS_DAMAGE_TYPE_ALL)
+        public static IntPtr EffectACDecrease(int nValue, int nModifyType = AC_DODGE_BONUS, int nDamageType = AC_VS_DAMAGE_TYPE_ALL)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nDamageType);
             NWN.Internal.NativeFunctions.StackPushInteger(nModifyType);
             NWN.Internal.NativeFunctions.StackPushInteger(nValue);
             NWN.Internal.NativeFunctions.CallBuiltIn(450);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -5587,11 +5590,11 @@ namespace NWN
         ///    50 = 50% slower
         ///    99 = almost immobile
         /// </summary>
-        public static NWN.Effect EffectMovementSpeedDecrease(int nPercentChange)
+        public static IntPtr EffectMovementSpeedDecrease(int nPercentChange)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nPercentChange);
             NWN.Internal.NativeFunctions.CallBuiltIn(451);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -5604,35 +5607,35 @@ namespace NWN
         ///  - nValue: size of the Saving Throw decrease
         ///  - nSaveType: SAVING_THROW_TYPE_* (e.g. SAVING_THROW_TYPE_ACID )
         /// </summary>
-        public static NWN.Effect EffectSavingThrowDecrease(int nSave, int nValue, int nSaveType = SAVING_THROW_TYPE_ALL)
+        public static IntPtr EffectSavingThrowDecrease(int nSave, int nValue, int nSaveType = SAVING_THROW_TYPE_ALL)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nSaveType);
             NWN.Internal.NativeFunctions.StackPushInteger(nValue);
             NWN.Internal.NativeFunctions.StackPushInteger(nSave);
             NWN.Internal.NativeFunctions.CallBuiltIn(452);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
         ///  Create a Skill Decrease effect.
         ///  * Returns an effect of type EFFECT_TYPE_INVALIDEFFECT if nSkill is invalid.
         /// </summary>
-        public static NWN.Effect EffectSkillDecrease(int nSkill, int nValue)
+        public static IntPtr EffectSkillDecrease(int nSkill, int nValue)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nValue);
             NWN.Internal.NativeFunctions.StackPushInteger(nSkill);
             NWN.Internal.NativeFunctions.CallBuiltIn(453);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
         ///  Create a Spell Resistance Decrease effect.
         /// </summary>
-        public static NWN.Effect EffectSpellResistanceDecrease(int nValue)
+        public static IntPtr EffectSpellResistanceDecrease(int nValue)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nValue);
             NWN.Internal.NativeFunctions.CallBuiltIn(454);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -5661,11 +5664,11 @@ namespace NWN
         ///  * Returns an effect of type EFFECT_TYPE_INVALIDEFFECT if nInvisibilityType
         ///    is invalid.
         /// </summary>
-        public static NWN.Effect EffectInvisibility(int nInvisibilityType)
+        public static IntPtr EffectInvisibility(int nInvisibilityType)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nInvisibilityType);
             NWN.Internal.NativeFunctions.CallBuiltIn(457);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -5675,21 +5678,21 @@ namespace NWN
         ///  * Returns an effect of type EFFECT_TYPE_INVALIDEFFECT if nPercentage < 1 or
         ///    nPercentage > 100.
         /// </summary>
-        public static NWN.Effect EffectConcealment(int nPercentage, int nMissType = MISS_CHANCE_TYPE_NORMAL)
+        public static IntPtr EffectConcealment(int nPercentage, int nMissType = MISS_CHANCE_TYPE_NORMAL)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nMissType);
             NWN.Internal.NativeFunctions.StackPushInteger(nPercentage);
             NWN.Internal.NativeFunctions.CallBuiltIn(458);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
         ///  Create a Darkness effect.
         /// </summary>
-        public static NWN.Effect EffectDarkness()
+        public static IntPtr EffectDarkness()
         {
             NWN.Internal.NativeFunctions.CallBuiltIn(459);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -5698,20 +5701,20 @@ namespace NWN
         ///  cause the dispel effect to use the level of the creature that created the
         ///  effect.
         /// </summary>
-        public static NWN.Effect EffectDispelMagicAll(int nCasterLevel = USE_CREATURE_LEVEL)
+        public static IntPtr EffectDispelMagicAll(int nCasterLevel = USE_CREATURE_LEVEL)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nCasterLevel);
             NWN.Internal.NativeFunctions.CallBuiltIn(460);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
         ///  Create an Ultravision effect.
         /// </summary>
-        public static NWN.Effect EffectUltravision()
+        public static IntPtr EffectUltravision()
         {
             NWN.Internal.NativeFunctions.CallBuiltIn(461);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -5719,23 +5722,23 @@ namespace NWN
         ///  - nNumLevels: the number of negative levels to apply.
         ///  * Returns an effect of type EFFECT_TYPE_INVALIDEFFECT if nNumLevels > 100.
         /// </summary>
-        public static NWN.Effect EffectNegativeLevel(int nNumLevels, int bHPBonus = FALSE)
+        public static IntPtr EffectNegativeLevel(int nNumLevels, int bHPBonus = FALSE)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(bHPBonus);
             NWN.Internal.NativeFunctions.StackPushInteger(nNumLevels);
             NWN.Internal.NativeFunctions.CallBuiltIn(462);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
         ///  Create a Polymorph effect.
         /// </summary>
-        public static NWN.Effect EffectPolymorph(int nPolymorphSelection, int nLocked = FALSE)
+        public static IntPtr EffectPolymorph(int nPolymorphSelection, int nLocked = FALSE)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nLocked);
             NWN.Internal.NativeFunctions.StackPushInteger(nPolymorphSelection);
             NWN.Internal.NativeFunctions.CallBuiltIn(463);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -5743,47 +5746,47 @@ namespace NWN
         ///  - nDifficultyClass: must be a non-zero, positive number
         ///  * Returns an effect of type EFFECT_TYPE_INVALIDEFFECT if nDifficultyClass <= 0.
         /// </summary>
-        public static NWN.Effect EffectSanctuary(int nDifficultyClass)
+        public static IntPtr EffectSanctuary(int nDifficultyClass)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nDifficultyClass);
             NWN.Internal.NativeFunctions.CallBuiltIn(464);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
         ///  Create a True Seeing effect.
         /// </summary>
-        public static NWN.Effect EffectTrueSeeing()
+        public static IntPtr EffectTrueSeeing()
         {
             NWN.Internal.NativeFunctions.CallBuiltIn(465);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
         ///  Create a See Invisible effect.
         /// </summary>
-        public static NWN.Effect EffectSeeInvisible()
+        public static IntPtr EffectSeeInvisible()
         {
             NWN.Internal.NativeFunctions.CallBuiltIn(466);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
         ///  Create a Time Stop effect.
         /// </summary>
-        public static NWN.Effect EffectTimeStop()
+        public static IntPtr EffectTimeStop()
         {
             NWN.Internal.NativeFunctions.CallBuiltIn(467);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
         ///  Create a Blindness effect.
         /// </summary>
-        public static NWN.Effect EffectBlindness()
+        public static IntPtr EffectBlindness()
         {
             NWN.Internal.NativeFunctions.CallBuiltIn(468);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -5845,13 +5848,13 @@ namespace NWN
         ///    nMaxSpellLevelAbsorbed is not between -1 and 9 inclusive, or nSpellSchool
         ///    is invalid.
         /// </summary>
-        public static NWN.Effect EffectSpellLevelAbsorption(int nMaxSpellLevelAbsorbed, int nTotalSpellLevelsAbsorbed = 0, int nSpellSchool = SPELL_SCHOOL_GENERAL)
+        public static IntPtr EffectSpellLevelAbsorption(int nMaxSpellLevelAbsorbed, int nTotalSpellLevelsAbsorbed = 0, int nSpellSchool = SPELL_SCHOOL_GENERAL)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nSpellSchool);
             NWN.Internal.NativeFunctions.StackPushInteger(nTotalSpellLevelsAbsorbed);
             NWN.Internal.NativeFunctions.StackPushInteger(nMaxSpellLevelAbsorbed);
             NWN.Internal.NativeFunctions.CallBuiltIn(472);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -5860,11 +5863,11 @@ namespace NWN
         ///  cause the dispel effect to use the level of the creature that created the
         ///  effect.
         /// </summary>
-        public static NWN.Effect EffectDispelMagicBest(int nCasterLevel = USE_CREATURE_LEVEL)
+        public static IntPtr EffectDispelMagicBest(int nCasterLevel = USE_CREATURE_LEVEL)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nCasterLevel);
             NWN.Internal.NativeFunctions.CallBuiltIn(473);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -5920,12 +5923,12 @@ namespace NWN
         ///  * Returns an effect of type EFFECT_TYPE_INVALIDEFFECT if nPercentage < 1 or
         ///    nPercentage > 100.
         /// </summary>
-        public static NWN.Effect EffectMissChance(int nPercentage, int nMissChanceType = MISS_CHANCE_TYPE_NORMAL)
+        public static IntPtr EffectMissChance(int nPercentage, int nMissChanceType = MISS_CHANCE_TYPE_NORMAL)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nMissChanceType);
             NWN.Internal.NativeFunctions.StackPushInteger(nPercentage);
             NWN.Internal.NativeFunctions.CallBuiltIn(477);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -5956,12 +5959,12 @@ namespace NWN
         ///  - nAnimation determines which appear and disappear animations to use. Most creatures
         ///  only have animation 1, although a few have 2 (like beholders)
         /// </summary>
-        public static NWN.Effect EffectDisappearAppear(NWN.Location lLocation, int nAnimation = 1)
+        public static IntPtr EffectDisappearAppear(IntPtr lLocation, int nAnimation = 1)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nAnimation);
-            NWN.Internal.NativeFunctions.StackPushLocation(lLocation.Handle);
+            NWN.Internal.NativeFunctions.StackPushLocation(lLocation);
             NWN.Internal.NativeFunctions.CallBuiltIn(480);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -5970,11 +5973,11 @@ namespace NWN
         ///  - nAnimation determines which appear and disappear animations to use. Most creatures
         ///  only have animation 1, although a few have 2 (like beholders)
         /// </summary>
-        public static NWN.Effect EffectDisappear(int nAnimation = 1)
+        public static IntPtr EffectDisappear(int nAnimation = 1)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nAnimation);
             NWN.Internal.NativeFunctions.CallBuiltIn(481);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -5982,11 +5985,11 @@ namespace NWN
         ///  - nAnimation determines which appear and disappear animations to use. Most creatures
         ///  only have animation 1, although a few have 2 (like beholders)
         /// </summary>
-        public static NWN.Effect EffectAppear(int nAnimation = 1)
+        public static IntPtr EffectAppear(int nAnimation = 1)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nAnimation);
             NWN.Internal.NativeFunctions.CallBuiltIn(482);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -6014,11 +6017,11 @@ namespace NWN
         ///  - nAttacks: maximum is 5, even with the effect stacked
         ///  * Returns an effect of type EFFECT_TYPE_INVALIDEFFECT if nAttacks > 5.
         /// </summary>
-        public static NWN.Effect EffectModifyAttacks(int nAttacks)
+        public static IntPtr EffectModifyAttacks(int nAttacks)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nAttacks);
             NWN.Internal.NativeFunctions.CallBuiltIn(485);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -6041,13 +6044,13 @@ namespace NWN
         ///  NOTE! You *must* use the DAMAGE_BONUS_* constants! Using other values may
         ///        result in odd behaviour.
         /// </summary>
-        public static NWN.Effect EffectDamageShield(int nDamageAmount, int nRandomAmount, int nDamageType)
+        public static IntPtr EffectDamageShield(int nDamageAmount, int nRandomAmount, int nDamageType)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nDamageType);
             NWN.Internal.NativeFunctions.StackPushInteger(nRandomAmount);
             NWN.Internal.NativeFunctions.StackPushInteger(nDamageAmount);
             NWN.Internal.NativeFunctions.CallBuiltIn(487);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -6229,10 +6232,10 @@ namespace NWN
         ///  - lTarget
         ///  - nProjectilePathType: PROJECTILE_PATH_TYPE_*
         /// </summary>
-        public static void ActionCastFakeSpellAtLocation(int nSpell, NWN.Location lTarget, int nProjectilePathType = PROJECTILE_PATH_TYPE_DEFAULT)
+        public static void ActionCastFakeSpellAtLocation(int nSpell, IntPtr lTarget, int nProjectilePathType = PROJECTILE_PATH_TYPE_DEFAULT)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nProjectilePathType);
-            NWN.Internal.NativeFunctions.StackPushLocation(lTarget.Handle);
+            NWN.Internal.NativeFunctions.StackPushLocation(lTarget);
             NWN.Internal.NativeFunctions.StackPushInteger(nSpell);
             NWN.Internal.NativeFunctions.CallBuiltIn(502);
         }
@@ -6329,7 +6332,7 @@ namespace NWN
         ///  - sCreatureTemplate3
         ///  - sCreatureTemplate4
         /// </summary>
-        public static NWN.Effect EffectSwarm(int nLooping, string sCreatureTemplate1, string sCreatureTemplate2 = "", string sCreatureTemplate3 = "", string sCreatureTemplate4 = "")
+        public static IntPtr EffectSwarm(int nLooping, string sCreatureTemplate1, string sCreatureTemplate2 = "", string sCreatureTemplate3 = "", string sCreatureTemplate4 = "")
         {
             NWN.Internal.NativeFunctions.StackPushStringUTF8(sCreatureTemplate4);
             NWN.Internal.NativeFunctions.StackPushStringUTF8(sCreatureTemplate3);
@@ -6337,7 +6340,7 @@ namespace NWN
             NWN.Internal.NativeFunctions.StackPushStringUTF8(sCreatureTemplate1);
             NWN.Internal.NativeFunctions.StackPushInteger(nLooping);
             NWN.Internal.NativeFunctions.CallBuiltIn(510);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -6374,11 +6377,11 @@ namespace NWN
         ///  - nMainLight1Color: TILE_MAIN_LIGHT_COLOR_*
         ///  - nMainLight2Color: TILE_MAIN_LIGHT_COLOR_*
         /// </summary>
-        public static void SetTileMainLightColor(NWN.Location lTileLocation, int nMainLight1Color, int nMainLight2Color)
+        public static void SetTileMainLightColor(IntPtr lTileLocation, int nMainLight1Color, int nMainLight2Color)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nMainLight2Color);
             NWN.Internal.NativeFunctions.StackPushInteger(nMainLight1Color);
-            NWN.Internal.NativeFunctions.StackPushLocation(lTileLocation.Handle);
+            NWN.Internal.NativeFunctions.StackPushLocation(lTileLocation);
             NWN.Internal.NativeFunctions.CallBuiltIn(514);
         }
 
@@ -6389,11 +6392,11 @@ namespace NWN
         ///  - nSourceLight1Color: TILE_SOURCE_LIGHT_COLOR_*
         ///  - nSourceLight2Color: TILE_SOURCE_LIGHT_COLOR_*
         /// </summary>
-        public static void SetTileSourceLightColor(NWN.Location lTileLocation, int nSourceLight1Color, int nSourceLight2Color)
+        public static void SetTileSourceLightColor(IntPtr lTileLocation, int nSourceLight1Color, int nSourceLight2Color)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nSourceLight2Color);
             NWN.Internal.NativeFunctions.StackPushInteger(nSourceLight1Color);
-            NWN.Internal.NativeFunctions.StackPushLocation(lTileLocation.Handle);
+            NWN.Internal.NativeFunctions.StackPushLocation(lTileLocation);
             NWN.Internal.NativeFunctions.CallBuiltIn(515);
         }
 
@@ -6413,9 +6416,9 @@ namespace NWN
         ///  lTile.
         ///  - lTile: the vector part of this is the tile grid (x,y) coordinate of the tile.
         /// </summary>
-        public static int GetTileMainLight1Color(NWN.Location lTile)
+        public static int GetTileMainLight1Color(IntPtr lTile)
         {
-            NWN.Internal.NativeFunctions.StackPushLocation(lTile.Handle);
+            NWN.Internal.NativeFunctions.StackPushLocation(lTile);
             NWN.Internal.NativeFunctions.CallBuiltIn(517);
             return NWN.Internal.NativeFunctions.StackPopInteger();
         }
@@ -6426,9 +6429,9 @@ namespace NWN
         ///  - lTile: the vector part of this is the tile grid (x,y) coordinate of the
         ///    tile.
         /// </summary>
-        public static int GetTileMainLight2Color(NWN.Location lTile)
+        public static int GetTileMainLight2Color(IntPtr lTile)
         {
-            NWN.Internal.NativeFunctions.StackPushLocation(lTile.Handle);
+            NWN.Internal.NativeFunctions.StackPushLocation(lTile);
             NWN.Internal.NativeFunctions.CallBuiltIn(518);
             return NWN.Internal.NativeFunctions.StackPopInteger();
         }
@@ -6439,9 +6442,9 @@ namespace NWN
         ///  - lTile: the vector part of this is the tile grid (x,y) coordinate of the
         ///    tile.
         /// </summary>
-        public static int GetTileSourceLight1Color(NWN.Location lTile)
+        public static int GetTileSourceLight1Color(IntPtr lTile)
         {
-            NWN.Internal.NativeFunctions.StackPushLocation(lTile.Handle);
+            NWN.Internal.NativeFunctions.StackPushLocation(lTile);
             NWN.Internal.NativeFunctions.CallBuiltIn(519);
             return NWN.Internal.NativeFunctions.StackPopInteger();
         }
@@ -6452,9 +6455,9 @@ namespace NWN
         ///  - lTile: the vector part of this is the tile grid (x,y) coordinate of the
         ///    tile.
         /// </summary>
-        public static int GetTileSourceLight2Color(NWN.Location lTile)
+        public static int GetTileSourceLight2Color(IntPtr lTile)
         {
-            NWN.Internal.NativeFunctions.StackPushLocation(lTile.Handle);
+            NWN.Internal.NativeFunctions.StackPushLocation(lTile);
             NWN.Internal.NativeFunctions.CallBuiltIn(520);
             return NWN.Internal.NativeFunctions.StackPopInteger();
         }
@@ -6847,11 +6850,11 @@ namespace NWN
         ///  - nHitDice: a positive number representing the number of hit dice for the
         /// /  decrease
         /// </summary>
-        public static NWN.Effect EffectTurnResistanceDecrease(int nHitDice)
+        public static IntPtr EffectTurnResistanceDecrease(int nHitDice)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nHitDice);
             NWN.Internal.NativeFunctions.CallBuiltIn(552);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -6859,11 +6862,11 @@ namespace NWN
         ///  - nHitDice: a positive number representing the number of hit dice for the
         ///    increase
         /// </summary>
-        public static NWN.Effect EffectTurnResistanceIncrease(int nHitDice)
+        public static IntPtr EffectTurnResistanceIncrease(int nHitDice)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nHitDice);
             NWN.Internal.NativeFunctions.CallBuiltIn(553);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -7211,10 +7214,10 @@ namespace NWN
         ///  returns an effect that will petrify the target
         ///  * currently applies EffectParalyze and the stoneskin visual effect.
         /// </summary>
-        public static NWN.Effect EffectPetrify()
+        public static IntPtr EffectPetrify()
         {
             NWN.Internal.NativeFunctions.CallBuiltIn(583);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -7243,10 +7246,10 @@ namespace NWN
         ///  returns an effect that is guaranteed to paralyze a creature.
         ///  this effect is identical to EffectParalyze except that it cannot be resisted.
         /// </summary>
-        public static NWN.Effect EffectCutsceneParalyze()
+        public static IntPtr EffectCutsceneParalyze()
         {
             NWN.Internal.NativeFunctions.CallBuiltIn(585);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -7316,10 +7319,10 @@ namespace NWN
         ///  The var name must be unique across the entire database, regardless of the variable type.
         ///  If you want a variable to pertain to a specific player in the game, provide a player object.
         /// </summary>
-        public static void SetCampaignVector(string sCampaignName, string sVarName, NWN.Vector? vVector, uint oPlayer = OBJECT_INVALID)
+        public static void SetCampaignVector(string sCampaignName, string sVarName, Vector3? vVector, uint oPlayer = OBJECT_INVALID)
         {
             NWN.Internal.NativeFunctions.StackPushObject(oPlayer);
-            NWN.Internal.NativeFunctions.StackPushVector(vVector.HasValue ? vVector.Value : new NWN.Vector());
+            NWN.Internal.NativeFunctions.StackPushVector(vVector.HasValue ? vVector.Value : new Vector3());
             NWN.Internal.NativeFunctions.StackPushStringUTF8(sVarName);
             NWN.Internal.NativeFunctions.StackPushStringUTF8(sCampaignName);
             NWN.Internal.NativeFunctions.CallBuiltIn(591);
@@ -7331,10 +7334,10 @@ namespace NWN
         ///  The var name must be unique across the entire database, regardless of the variable type.
         ///  If you want a variable to pertain to a specific player in the game, provide a player object.
         /// </summary>
-        public static void SetCampaignLocation(string sCampaignName, string sVarName, NWN.Location locLocation, uint oPlayer = OBJECT_INVALID)
+        public static void SetCampaignLocation(string sCampaignName, string sVarName, IntPtr locLocation, uint oPlayer = OBJECT_INVALID)
         {
             NWN.Internal.NativeFunctions.StackPushObject(oPlayer);
-            NWN.Internal.NativeFunctions.StackPushLocation(locLocation.Handle);
+            NWN.Internal.NativeFunctions.StackPushLocation(locLocation);
             NWN.Internal.NativeFunctions.StackPushStringUTF8(sVarName);
             NWN.Internal.NativeFunctions.StackPushStringUTF8(sCampaignName);
             NWN.Internal.NativeFunctions.CallBuiltIn(592);
@@ -7400,7 +7403,7 @@ namespace NWN
         ///  The var name must be unique across the entire database, regardless of the variable type.
         ///  If you want a variable to pertain to a specific player in the game, provide a player object.
         /// </summary>
-        public static NWN.Vector GetCampaignVector(string sCampaignName, string sVarName, uint oPlayer = OBJECT_INVALID)
+        public static Vector3 GetCampaignVector(string sCampaignName, string sVarName, uint oPlayer = OBJECT_INVALID)
         {
             NWN.Internal.NativeFunctions.StackPushObject(oPlayer);
             NWN.Internal.NativeFunctions.StackPushStringUTF8(sVarName);
@@ -7415,13 +7418,13 @@ namespace NWN
         ///  The var name must be unique across the entire database, regardless of the variable type.
         ///  If you want a variable to pertain to a specific player in the game, provide a player object.
         /// </summary>
-        public static NWN.Location GetCampaignLocation(string sCampaignName, string sVarName, uint oPlayer = OBJECT_INVALID)
+        public static IntPtr GetCampaignLocation(string sCampaignName, string sVarName, uint oPlayer = OBJECT_INVALID)
         {
             NWN.Internal.NativeFunctions.StackPushObject(oPlayer);
             NWN.Internal.NativeFunctions.StackPushStringUTF8(sVarName);
             NWN.Internal.NativeFunctions.StackPushStringUTF8(sCampaignName);
             NWN.Internal.NativeFunctions.CallBuiltIn(598);
-            return new NWN.Location(NWN.Internal.NativeFunctions.StackPopLocation());
+            return NWN.Internal.NativeFunctions.StackPopLocation();
         }
 
         /// <summary>
@@ -7446,11 +7449,11 @@ namespace NWN
         ///  If the object is a creature, they will be created at the location.
         ///  If a new tag is specified, it will be assigned to the new object.
         /// </summary>
-        public static uint CopyObject(uint oSource, NWN.Location locLocation, uint oOwner = OBJECT_INVALID, string sNewTag = "")
+        public static uint CopyObject(uint oSource, IntPtr locLocation, uint oOwner = OBJECT_INVALID, string sNewTag = "")
         {
             NWN.Internal.NativeFunctions.StackPushStringUTF8(sNewTag);
             NWN.Internal.NativeFunctions.StackPushObject(oOwner);
-            NWN.Internal.NativeFunctions.StackPushLocation(locLocation.Handle);
+            NWN.Internal.NativeFunctions.StackPushLocation(locLocation);
             NWN.Internal.NativeFunctions.StackPushObject(oSource);
             NWN.Internal.NativeFunctions.CallBuiltIn(600);
             return NWN.Internal.NativeFunctions.StackPopObject();
@@ -7491,11 +7494,11 @@ namespace NWN
         ///  If you specify an owner, the object will try to be created in their repository
         ///  If the owner can't handle the item (or if it's a creature) it will be created on the ground.
         /// </summary>
-        public static uint RetrieveCampaignObject(string sCampaignName, string sVarName, NWN.Location locLocation, uint oOwner = OBJECT_INVALID, uint oPlayer = OBJECT_INVALID)
+        public static uint RetrieveCampaignObject(string sCampaignName, string sVarName, IntPtr locLocation, uint oOwner = OBJECT_INVALID, uint oPlayer = OBJECT_INVALID)
         {
             NWN.Internal.NativeFunctions.StackPushObject(oPlayer);
             NWN.Internal.NativeFunctions.StackPushObject(oOwner);
-            NWN.Internal.NativeFunctions.StackPushLocation(locLocation.Handle);
+            NWN.Internal.NativeFunctions.StackPushLocation(locLocation);
             NWN.Internal.NativeFunctions.StackPushStringUTF8(sVarName);
             NWN.Internal.NativeFunctions.StackPushStringUTF8(sCampaignName);
             NWN.Internal.NativeFunctions.CallBuiltIn(603);
@@ -7506,10 +7509,10 @@ namespace NWN
         ///  Returns an effect that is guaranteed to dominate a creature
         ///  Like EffectDominated but cannot be resisted
         /// </summary>
-        public static NWN.Effect EffectCutsceneDominated()
+        public static IntPtr EffectCutsceneDominated()
         {
             NWN.Internal.NativeFunctions.CallBuiltIn(604);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -7569,11 +7572,11 @@ namespace NWN
         ///  adds an item property to the specified item
         ///  Only temporary and permanent duration types are allowed.
         /// </summary>
-        public static void AddItemProperty(int nDurationType, NWN.ItemProperty ipProperty, uint oItem, float fDuration = 0.0f)
+        public static void AddItemProperty(int nDurationType, IntPtr ipProperty, uint oItem, float fDuration = 0.0f)
         {
             NWN.Internal.NativeFunctions.StackPushFloat(fDuration);
             NWN.Internal.NativeFunctions.StackPushObject(oItem);
-            NWN.Internal.NativeFunctions.StackPushItemProperty(ipProperty.Handle);
+            NWN.Internal.NativeFunctions.StackPushItemProperty(ipProperty);
             NWN.Internal.NativeFunctions.StackPushInteger(nDurationType);
             NWN.Internal.NativeFunctions.CallBuiltIn(609);
         }
@@ -7581,9 +7584,9 @@ namespace NWN
         /// <summary>
         ///  removes an item property from the specified item
         /// </summary>
-        public static void RemoveItemProperty(uint oItem, NWN.ItemProperty ipProperty)
+        public static void RemoveItemProperty(uint oItem, IntPtr ipProperty)
         {
-            NWN.Internal.NativeFunctions.StackPushItemProperty(ipProperty.Handle);
+            NWN.Internal.NativeFunctions.StackPushItemProperty(ipProperty);
             NWN.Internal.NativeFunctions.StackPushObject(oItem);
             NWN.Internal.NativeFunctions.CallBuiltIn(610);
         }
@@ -7591,9 +7594,9 @@ namespace NWN
         /// <summary>
         ///  if the item property is valid this will return true
         /// </summary>
-        public static int GetIsItemPropertyValid(NWN.ItemProperty ipProperty)
+        public static int GetIsItemPropertyValid(IntPtr ipProperty)
         {
-            NWN.Internal.NativeFunctions.StackPushItemProperty(ipProperty.Handle);
+            NWN.Internal.NativeFunctions.StackPushItemProperty(ipProperty);
             NWN.Internal.NativeFunctions.CallBuiltIn(611);
             return NWN.Internal.NativeFunctions.StackPopInteger();
         }
@@ -7601,30 +7604,30 @@ namespace NWN
         /// <summary>
         ///  Gets the first item property on an item
         /// </summary>
-        public static NWN.ItemProperty GetFirstItemProperty(uint oItem)
+        public static IntPtr GetFirstItemProperty(uint oItem)
         {
             NWN.Internal.NativeFunctions.StackPushObject(oItem);
             NWN.Internal.NativeFunctions.CallBuiltIn(612);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
         ///  Will keep retrieving the next and the next item property on an Item,
         ///  will return an invalid item property when the list is empty.
         /// </summary>
-        public static NWN.ItemProperty GetNextItemProperty(uint oItem)
+        public static IntPtr GetNextItemProperty(uint oItem)
         {
             NWN.Internal.NativeFunctions.StackPushObject(oItem);
             NWN.Internal.NativeFunctions.CallBuiltIn(613);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
         ///  will return the item property type (ie. holy avenger)
         /// </summary>
-        public static int GetItemPropertyType(NWN.ItemProperty ip)
+        public static int GetItemPropertyType(IntPtr ip)
         {
-            NWN.Internal.NativeFunctions.StackPushItemProperty(ip.Handle);
+            NWN.Internal.NativeFunctions.StackPushItemProperty(ip);
             NWN.Internal.NativeFunctions.CallBuiltIn(614);
             return NWN.Internal.NativeFunctions.StackPopInteger();
         }
@@ -7632,9 +7635,9 @@ namespace NWN
         /// <summary>
         ///  will return the duration type of the item property
         /// </summary>
-        public static int GetItemPropertyDurationType(NWN.ItemProperty ip)
+        public static int GetItemPropertyDurationType(IntPtr ip)
         {
-            NWN.Internal.NativeFunctions.StackPushItemProperty(ip.Handle);
+            NWN.Internal.NativeFunctions.StackPushItemProperty(ip);
             NWN.Internal.NativeFunctions.CallBuiltIn(615);
             return NWN.Internal.NativeFunctions.StackPopInteger();
         }
@@ -7644,12 +7647,12 @@ namespace NWN
         ///  ability constant(IP_CONST_ABILITY_*) and the bonus.  The bonus should
         ///  be a positive integer between 1 and 12.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyAbilityBonus(int nAbility, int nBonus)
+        public static IntPtr ItemPropertyAbilityBonus(int nAbility, int nBonus)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nBonus);
             NWN.Internal.NativeFunctions.StackPushInteger(nAbility);
             NWN.Internal.NativeFunctions.CallBuiltIn(616);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -7657,11 +7660,11 @@ namespace NWN
         ///  The bonus should be a positive integer between 1 and 20. The modifier
         ///  type depends on the item it is being applied to.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyACBonus(int nBonus)
+        public static IntPtr ItemPropertyACBonus(int nBonus)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nBonus);
             NWN.Internal.NativeFunctions.CallBuiltIn(617);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -7671,12 +7674,12 @@ namespace NWN
         ///  The AC bonus should be an integer between 1 and 20.  The modifier
         ///  type depends on the item it is being applied to.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyACBonusVsAlign(int nAlignGroup, int nACBonus)
+        public static IntPtr ItemPropertyACBonusVsAlign(int nAlignGroup, int nACBonus)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nACBonus);
             NWN.Internal.NativeFunctions.StackPushInteger(nAlignGroup);
             NWN.Internal.NativeFunctions.CallBuiltIn(618);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -7687,12 +7690,12 @@ namespace NWN
         ///  NOTE: Only the first 3 damage types may be used here, the 3 basic
         ///        physical types.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyACBonusVsDmgType(int nDamageType, int nACBonus)
+        public static IntPtr ItemPropertyACBonusVsDmgType(int nDamageType, int nACBonus)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nACBonus);
             NWN.Internal.NativeFunctions.StackPushInteger(nDamageType);
             NWN.Internal.NativeFunctions.CallBuiltIn(619);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -7701,12 +7704,12 @@ namespace NWN
         ///  bonus should be an integer between 1 and 20.  The modifier type depends
         ///  on the item it is being applied to.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyACBonusVsRace(int nRace, int nACBonus)
+        public static IntPtr ItemPropertyACBonusVsRace(int nRace, int nACBonus)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nACBonus);
             NWN.Internal.NativeFunctions.StackPushInteger(nRace);
             NWN.Internal.NativeFunctions.CallBuiltIn(620);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -7715,12 +7718,12 @@ namespace NWN
         ///  bonus.  The AC bonus should be an integer between 1 and 20.  The
         ///  modifier type depends on the item it is being applied to.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyACBonusVsSAlign(int nAlign, int nACBonus)
+        public static IntPtr ItemPropertyACBonusVsSAlign(int nAlign, int nACBonus)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nACBonus);
             NWN.Internal.NativeFunctions.StackPushInteger(nAlign);
             NWN.Internal.NativeFunctions.CallBuiltIn(621);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -7728,11 +7731,11 @@ namespace NWN
         ///  enhancement bonus.  The Enhancement bonus should be an integer between
         ///  1 and 20.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyEnhancementBonus(int nEnhancementBonus)
+        public static IntPtr ItemPropertyEnhancementBonus(int nEnhancementBonus)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nEnhancementBonus);
             NWN.Internal.NativeFunctions.CallBuiltIn(622);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -7741,12 +7744,12 @@ namespace NWN
         ///  and the enhancement bonus.  The Enhancement bonus should be an integer
         ///  between 1 and 20.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyEnhancementBonusVsAlign(int nAlignGroup, int nBonus)
+        public static IntPtr ItemPropertyEnhancementBonusVsAlign(int nAlignGroup, int nBonus)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nBonus);
             NWN.Internal.NativeFunctions.StackPushInteger(nAlignGroup);
             NWN.Internal.NativeFunctions.CallBuiltIn(623);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -7755,12 +7758,12 @@ namespace NWN
         ///  enhancement bonus.  The enhancement bonus should be an integer between
         ///  1 and 20.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyEnhancementBonusVsRace(int nRace, int nBonus)
+        public static IntPtr ItemPropertyEnhancementBonusVsRace(int nRace, int nBonus)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nBonus);
             NWN.Internal.NativeFunctions.StackPushInteger(nRace);
             NWN.Internal.NativeFunctions.CallBuiltIn(624);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -7769,12 +7772,12 @@ namespace NWN
         ///  enhancement bonus.  The enhancement bonus should be an integer between
         ///  1 and 20.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyEnhancementBonusVsSAlign(int nAlign, int nBonus)
+        public static IntPtr ItemPropertyEnhancementBonusVsSAlign(int nAlign, int nBonus)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nBonus);
             NWN.Internal.NativeFunctions.StackPushInteger(nAlign);
             NWN.Internal.NativeFunctions.CallBuiltIn(625);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -7782,33 +7785,33 @@ namespace NWN
         ///  enhancement penalty.  The enhancement penalty should be a POSITIVE
         ///  integer between 1 and 5 (ie. 1 = -1).
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyEnhancementPenalty(int nPenalty)
+        public static IntPtr ItemPropertyEnhancementPenalty(int nPenalty)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nPenalty);
             NWN.Internal.NativeFunctions.CallBuiltIn(626);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
         ///  Returns Item property weight reduction.  You need to specify the weight
         ///  reduction constant(IP_CONST_REDUCEDWEIGHT_*).
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyWeightReduction(int nReduction)
+        public static IntPtr ItemPropertyWeightReduction(int nReduction)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nReduction);
             NWN.Internal.NativeFunctions.CallBuiltIn(627);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
         ///  Returns Item property Bonus Feat.  You need to specify the the feat
         ///  constant(IP_CONST_FEAT_*).
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyBonusFeat(int nFeat)
+        public static IntPtr ItemPropertyBonusFeat(int nFeat)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nFeat);
             NWN.Internal.NativeFunctions.CallBuiltIn(628);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -7817,12 +7820,12 @@ namespace NWN
         ///  spell casting class) and the level of the bonus spell.  The level of the
         ///  bonus spell should be an integer between 0 and 9.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyBonusLevelSpell(int nClass, int nSpellLevel)
+        public static IntPtr ItemPropertyBonusLevelSpell(int nClass, int nSpellLevel)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nSpellLevel);
             NWN.Internal.NativeFunctions.StackPushInteger(nClass);
             NWN.Internal.NativeFunctions.CallBuiltIn(629);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -8214,12 +8217,12 @@ namespace NWN
         ///           Special_Alcohol_Wine
         ///
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyCastSpell(int nSpell, int nNumUses)
+        public static IntPtr ItemPropertyCastSpell(int nSpell, int nNumUses)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nNumUses);
             NWN.Internal.NativeFunctions.StackPushInteger(nSpell);
             NWN.Internal.NativeFunctions.CallBuiltIn(630);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -8228,12 +8231,12 @@ namespace NWN
         ///  NOTE: not all the damage types will work, use only the following: Acid, Bludgeoning,
         ///        Cold, Electrical, Fire, Piercing, Slashing, Sonic.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyDamageBonus(int nDamageType, int nDamage)
+        public static IntPtr ItemPropertyDamageBonus(int nDamageType, int nDamage)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nDamage);
             NWN.Internal.NativeFunctions.StackPushInteger(nDamageType);
             NWN.Internal.NativeFunctions.CallBuiltIn(631);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -8243,13 +8246,13 @@ namespace NWN
         ///  NOTE: not all the damage types will work, use only the following: Acid, Bludgeoning,
         ///        Cold, Electrical, Fire, Piercing, Slashing, Sonic.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyDamageBonusVsAlign(int nAlignGroup, int nDamageType, int nDamage)
+        public static IntPtr ItemPropertyDamageBonusVsAlign(int nAlignGroup, int nDamageType, int nDamage)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nDamage);
             NWN.Internal.NativeFunctions.StackPushInteger(nDamageType);
             NWN.Internal.NativeFunctions.StackPushInteger(nAlignGroup);
             NWN.Internal.NativeFunctions.CallBuiltIn(632);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -8259,13 +8262,13 @@ namespace NWN
         ///  NOTE: not all the damage types will work, use only the following: Acid, Bludgeoning,
         ///        Cold, Electrical, Fire, Piercing, Slashing, Sonic.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyDamageBonusVsRace(int nRace, int nDamageType, int nDamage)
+        public static IntPtr ItemPropertyDamageBonusVsRace(int nRace, int nDamageType, int nDamage)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nDamage);
             NWN.Internal.NativeFunctions.StackPushInteger(nDamageType);
             NWN.Internal.NativeFunctions.StackPushInteger(nRace);
             NWN.Internal.NativeFunctions.CallBuiltIn(633);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -8275,13 +8278,13 @@ namespace NWN
         ///  NOTE: not all the damage types will work, use only the following: Acid, Bludgeoning,
         ///        Cold, Electrical, Fire, Piercing, Slashing, Sonic.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyDamageBonusVsSAlign(int nAlign, int nDamageType, int nDamage)
+        public static IntPtr ItemPropertyDamageBonusVsSAlign(int nAlign, int nDamageType, int nDamage)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nDamage);
             NWN.Internal.NativeFunctions.StackPushInteger(nDamageType);
             NWN.Internal.NativeFunctions.StackPushInteger(nAlign);
             NWN.Internal.NativeFunctions.CallBuiltIn(634);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -8291,23 +8294,23 @@ namespace NWN
         ///  NOTE: not all the damage types will work, use only the following: Acid, Bludgeoning,
         ///        Cold, Electrical, Fire, Piercing, Slashing, Sonic.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyDamageImmunity(int nDamageType, int nImmuneBonus)
+        public static IntPtr ItemPropertyDamageImmunity(int nDamageType, int nImmuneBonus)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nImmuneBonus);
             NWN.Internal.NativeFunctions.StackPushInteger(nDamageType);
             NWN.Internal.NativeFunctions.CallBuiltIn(635);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
         ///  Returns Item property damage penalty.  You must specify the damage penalty.
         ///  The damage penalty should be a POSITIVE integer between 1 and 5 (ie. 1 = -1).
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyDamagePenalty(int nPenalty)
+        public static IntPtr ItemPropertyDamagePenalty(int nPenalty)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nPenalty);
             NWN.Internal.NativeFunctions.CallBuiltIn(636);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -8316,12 +8319,12 @@ namespace NWN
         ///  and the amount of HP of damage constant(IP_CONST_DAMAGESOAK_*) will be soaked
         ///  up if your weapon is not of high enough enhancement.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyDamageReduction(int nEnhancement, int nHPSoak)
+        public static IntPtr ItemPropertyDamageReduction(int nEnhancement, int nHPSoak)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nHPSoak);
             NWN.Internal.NativeFunctions.StackPushInteger(nEnhancement);
             NWN.Internal.NativeFunctions.CallBuiltIn(637);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -8329,12 +8332,12 @@ namespace NWN
         ///  constant(IP_CONST_DAMAGETYPE_*) and the amount of HP of damage constant
         ///  (IP_CONST_DAMAGERESIST_*) that will be resisted against each round.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyDamageResistance(int nDamageType, int nHPResist)
+        public static IntPtr ItemPropertyDamageResistance(int nDamageType, int nHPResist)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nHPResist);
             NWN.Internal.NativeFunctions.StackPushInteger(nDamageType);
             NWN.Internal.NativeFunctions.CallBuiltIn(638);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -8342,21 +8345,21 @@ namespace NWN
         ///  constant(IP_CONST_DAMAGETYPE_*) that you want the user to be extra vulnerable to
         ///  and the percentage vulnerability constant(IP_CONST_DAMAGEVULNERABILITY_*).
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyDamageVulnerability(int nDamageType, int nVulnerability)
+        public static IntPtr ItemPropertyDamageVulnerability(int nDamageType, int nVulnerability)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nVulnerability);
             NWN.Internal.NativeFunctions.StackPushInteger(nDamageType);
             NWN.Internal.NativeFunctions.CallBuiltIn(639);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
         ///  Return Item property Darkvision.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyDarkvision()
+        public static IntPtr ItemPropertyDarkvision()
         {
             NWN.Internal.NativeFunctions.CallBuiltIn(640);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -8364,12 +8367,12 @@ namespace NWN
         ///  constant(IP_CONST_ABILITY_*) and the modifier constant.  The modifier must be
         ///  a POSITIVE integer between 1 and 10 (ie. 1 = -1).
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyDecreaseAbility(int nAbility, int nModifier)
+        public static IntPtr ItemPropertyDecreaseAbility(int nAbility, int nModifier)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nModifier);
             NWN.Internal.NativeFunctions.StackPushInteger(nAbility);
             NWN.Internal.NativeFunctions.CallBuiltIn(641);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -8377,12 +8380,12 @@ namespace NWN
         ///  modifier type constant(IP_CONST_ACMODIFIERTYPE_*) and the armor class penalty.
         ///  The penalty must be a POSITIVE integer between 1 and 5 (ie. 1 = -1).
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyDecreaseAC(int nModifierType, int nPenalty)
+        public static IntPtr ItemPropertyDecreaseAC(int nModifierType, int nPenalty)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nPenalty);
             NWN.Internal.NativeFunctions.StackPushInteger(nModifierType);
             NWN.Internal.NativeFunctions.CallBuiltIn(642);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -8390,12 +8393,12 @@ namespace NWN
         ///  skill to be decreased(SKILL_*) and the amount of the penalty.  The penalty
         ///  must be a POSITIVE integer between 1 and 10 (ie. 1 = -1).
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyDecreaseSkill(int nSkill, int nPenalty)
+        public static IntPtr ItemPropertyDecreaseSkill(int nSkill, int nPenalty)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nPenalty);
             NWN.Internal.NativeFunctions.StackPushInteger(nSkill);
             NWN.Internal.NativeFunctions.CallBuiltIn(643);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -8403,11 +8406,11 @@ namespace NWN
         ///  containers that reduce the weight of the objects inside them.  You must
         ///  specify the container weight reduction type constant(IP_CONST_CONTAINERWEIGHTRED_*).
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyContainerReducedWeight(int nContainerType)
+        public static IntPtr ItemPropertyContainerReducedWeight(int nContainerType)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nContainerType);
             NWN.Internal.NativeFunctions.CallBuiltIn(644);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -8417,11 +8420,11 @@ namespace NWN
         ///        here.
         ///  NOTE: It is also only applicable to melee weapons.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyExtraMeleeDamageType(int nDamageType)
+        public static IntPtr ItemPropertyExtraMeleeDamageType(int nDamageType)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nDamageType);
             NWN.Internal.NativeFunctions.CallBuiltIn(645);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -8431,60 +8434,60 @@ namespace NWN
         ///        here.
         ///  NOTE: It is also only applicable to ranged weapons.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyExtraRangeDamageType(int nDamageType)
+        public static IntPtr ItemPropertyExtraRangeDamageType(int nDamageType)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nDamageType);
             NWN.Internal.NativeFunctions.CallBuiltIn(646);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
         ///  Returns Item property haste.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyHaste()
+        public static IntPtr ItemPropertyHaste()
         {
             NWN.Internal.NativeFunctions.CallBuiltIn(647);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
         ///  Returns Item property Holy Avenger.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyHolyAvenger()
+        public static IntPtr ItemPropertyHolyAvenger()
         {
             NWN.Internal.NativeFunctions.CallBuiltIn(648);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
         ///  Returns Item property immunity to miscellaneous effects.  You must specify the
         ///  effect to which the user is immune, it is a constant(IP_CONST_IMMUNITYMISC_*).
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyImmunityMisc(int nImmunityType)
+        public static IntPtr ItemPropertyImmunityMisc(int nImmunityType)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nImmunityType);
             NWN.Internal.NativeFunctions.CallBuiltIn(649);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
         ///  Returns Item property improved evasion.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyImprovedEvasion()
+        public static IntPtr ItemPropertyImprovedEvasion()
         {
             NWN.Internal.NativeFunctions.CallBuiltIn(650);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
         ///  Returns Item property bonus spell resistance.  You must specify the bonus spell
         ///  resistance constant(IP_CONST_SPELLRESISTANCEBONUS_*).
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyBonusSpellResistance(int nBonus)
+        public static IntPtr ItemPropertyBonusSpellResistance(int nBonus)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nBonus);
             NWN.Internal.NativeFunctions.CallBuiltIn(651);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -8493,12 +8496,12 @@ namespace NWN
         ///  applied to and the bonus that is be applied.  The bonus must be an integer
         ///  between 1 and 20.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyBonusSavingThrowVsX(int nBonusType, int nBonus)
+        public static IntPtr ItemPropertyBonusSavingThrowVsX(int nBonusType, int nBonus)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nBonus);
             NWN.Internal.NativeFunctions.StackPushInteger(nBonusType);
             NWN.Internal.NativeFunctions.CallBuiltIn(652);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -8507,22 +8510,22 @@ namespace NWN
         ///  to which the user gets the bonus and the bonus that he/she will get.  The
         ///  bonus must be an integer between 1 and 20.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyBonusSavingThrow(int nBaseSaveType, int nBonus)
+        public static IntPtr ItemPropertyBonusSavingThrow(int nBaseSaveType, int nBonus)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nBonus);
             NWN.Internal.NativeFunctions.StackPushInteger(nBaseSaveType);
             NWN.Internal.NativeFunctions.CallBuiltIn(653);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
         ///  Returns Item property keen.  This means a critical threat range of 19-20 on a
         ///  weapon will be increased to 17-20 etc.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyKeen()
+        public static IntPtr ItemPropertyKeen()
         {
             NWN.Internal.NativeFunctions.CallBuiltIn(654);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -8530,12 +8533,12 @@ namespace NWN
         ///  light(IP_CONST_LIGHTBRIGHTNESS_*) and the color constant of the light
         ///  (IP_CONST_LIGHTCOLOR_*).
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyLight(int nBrightness, int nColor)
+        public static IntPtr ItemPropertyLight(int nBrightness, int nColor)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nColor);
             NWN.Internal.NativeFunctions.StackPushInteger(nBrightness);
             NWN.Internal.NativeFunctions.CallBuiltIn(655);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -8543,21 +8546,21 @@ namespace NWN
         ///  specify the maximum modifier for strength that is allowed on a ranged weapon.
         ///  The modifier must be a positive integer between 1 and 20.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyMaxRangeStrengthMod(int nModifier)
+        public static IntPtr ItemPropertyMaxRangeStrengthMod(int nModifier)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nModifier);
             NWN.Internal.NativeFunctions.CallBuiltIn(656);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
         ///  Returns Item property no damage.  This means the weapon will do no damage in
         ///  combat.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyNoDamage()
+        public static IntPtr ItemPropertyNoDamage()
         {
             NWN.Internal.NativeFunctions.CallBuiltIn(657);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -8601,13 +8604,13 @@ namespace NWN
         ///       STUN              :nSpecial is the duration/percentage of effecting victim.
         ///                          constant(IP_CONST_ONHIT_DURATION_*)
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyOnHitProps(int nProperty, int nSaveDC, int nSpecial = 0)
+        public static IntPtr ItemPropertyOnHitProps(int nProperty, int nSaveDC, int nSpecial = 0)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nSpecial);
             NWN.Internal.NativeFunctions.StackPushInteger(nSaveDC);
             NWN.Internal.NativeFunctions.StackPushInteger(nProperty);
             NWN.Internal.NativeFunctions.CallBuiltIn(658);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -8616,12 +8619,12 @@ namespace NWN
         ///  penalty to be applied.  The penalty must be a POSITIVE integer between 1 and 20
         ///  (ie. 1 = -1).
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyReducedSavingThrowVsX(int nBaseSaveType, int nPenalty)
+        public static IntPtr ItemPropertyReducedSavingThrowVsX(int nBaseSaveType, int nPenalty)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nPenalty);
             NWN.Internal.NativeFunctions.StackPushInteger(nBaseSaveType);
             NWN.Internal.NativeFunctions.CallBuiltIn(659);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -8630,23 +8633,23 @@ namespace NWN
         ///  to be applied.  The constant for the base type starts with (IP_CONST_SAVEBASETYPE_*).
         ///  The penalty must be a POSITIVE integer between 1 and 20 (ie. 1 = -1).
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyReducedSavingThrow(int nBonusType, int nPenalty)
+        public static IntPtr ItemPropertyReducedSavingThrow(int nBonusType, int nPenalty)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nPenalty);
             NWN.Internal.NativeFunctions.StackPushInteger(nBonusType);
             NWN.Internal.NativeFunctions.CallBuiltIn(660);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
         ///  Returns Item property regeneration.  You must specify the regeneration amount.
         ///  The amount must be an integer between 1 and 20.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyRegeneration(int nRegenAmount)
+        public static IntPtr ItemPropertyRegeneration(int nRegenAmount)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nRegenAmount);
             NWN.Internal.NativeFunctions.CallBuiltIn(661);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -8654,56 +8657,56 @@ namespace NWN
         ///  will get a bonus(SKILL_*) and the amount of the bonus.  The bonus amount must
         ///  be an integer between 1 and 50.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertySkillBonus(int nSkill, int nBonus)
+        public static IntPtr ItemPropertySkillBonus(int nSkill, int nBonus)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nBonus);
             NWN.Internal.NativeFunctions.StackPushInteger(nSkill);
             NWN.Internal.NativeFunctions.CallBuiltIn(662);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
         ///  Returns Item property spell immunity vs. specific spell.  You must specify the
         ///  spell to which the user will be immune(IP_CONST_IMMUNITYSPELL_*).
         /// </summary>
-        public static NWN.ItemProperty ItemPropertySpellImmunitySpecific(int nSpell)
+        public static IntPtr ItemPropertySpellImmunitySpecific(int nSpell)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nSpell);
             NWN.Internal.NativeFunctions.CallBuiltIn(663);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
         ///  Returns Item property spell immunity vs. spell school.  You must specify the
         ///  school to which the user will be immune(IP_CONST_SPELLSCHOOL_*).
         /// </summary>
-        public static NWN.ItemProperty ItemPropertySpellImmunitySchool(int nSchool)
+        public static IntPtr ItemPropertySpellImmunitySchool(int nSchool)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nSchool);
             NWN.Internal.NativeFunctions.CallBuiltIn(664);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
         ///  Returns Item property Thieves tools.  You must specify the modifier you wish
         ///  the tools to have.  The modifier must be an integer between 1 and 12.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyThievesTools(int nModifier)
+        public static IntPtr ItemPropertyThievesTools(int nModifier)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nModifier);
             NWN.Internal.NativeFunctions.CallBuiltIn(665);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
         ///  Returns Item property Attack bonus.  You must specify an attack bonus.  The bonus
         ///  must be an integer between 1 and 20.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyAttackBonus(int nBonus)
+        public static IntPtr ItemPropertyAttackBonus(int nBonus)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nBonus);
             NWN.Internal.NativeFunctions.CallBuiltIn(666);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -8711,12 +8714,12 @@ namespace NWN
         ///  alignment group constant(IP_CONST_ALIGNMENTGROUP_*) and the attack bonus.  The
         ///  bonus must be an integer between 1 and 20.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyAttackBonusVsAlign(int nAlignGroup, int nBonus)
+        public static IntPtr ItemPropertyAttackBonusVsAlign(int nAlignGroup, int nBonus)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nBonus);
             NWN.Internal.NativeFunctions.StackPushInteger(nAlignGroup);
             NWN.Internal.NativeFunctions.CallBuiltIn(667);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -8724,12 +8727,12 @@ namespace NWN
         ///  racial group constant(IP_CONST_RACIALTYPE_*) and the attack bonus.  The bonus
         ///  must be an integer between 1 and 20.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyAttackBonusVsRace(int nRace, int nBonus)
+        public static IntPtr ItemPropertyAttackBonusVsRace(int nRace, int nBonus)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nBonus);
             NWN.Internal.NativeFunctions.StackPushInteger(nRace);
             NWN.Internal.NativeFunctions.CallBuiltIn(668);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -8737,23 +8740,23 @@ namespace NWN
         ///  the alignment you want the bonus to work against(IP_CONST_ALIGNMENT_*) and the
         ///  attack bonus.  The bonus must be an integer between 1 and 20.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyAttackBonusVsSAlign(int nAlignment, int nBonus)
+        public static IntPtr ItemPropertyAttackBonusVsSAlign(int nAlignment, int nBonus)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nBonus);
             NWN.Internal.NativeFunctions.StackPushInteger(nAlignment);
             NWN.Internal.NativeFunctions.CallBuiltIn(669);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
         ///  Returns Item property attack penalty.  You must specify the attack penalty.
         ///  The penalty must be a POSITIVE integer between 1 and 5 (ie. 1 = -1).
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyAttackPenalty(int nPenalty)
+        public static IntPtr ItemPropertyAttackPenalty(int nPenalty)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nPenalty);
             NWN.Internal.NativeFunctions.CallBuiltIn(670);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -8763,96 +8766,96 @@ namespace NWN
         ///  bonus).  For this parmeter you use the constants beginning with:
         ///       (IP_CONST_UNLIMITEDAMMO_*).
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyUnlimitedAmmo(int nAmmoDamage = IP_CONST_UNLIMITEDAMMO_BASIC)
+        public static IntPtr ItemPropertyUnlimitedAmmo(int nAmmoDamage = IP_CONST_UNLIMITEDAMMO_BASIC)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nAmmoDamage);
             NWN.Internal.NativeFunctions.CallBuiltIn(671);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
         ///  Returns Item property limit use by alignment group.  You must specify the
         ///  alignment group(s) that you want to be able to use this item(IP_CONST_ALIGNMENTGROUP_*).
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyLimitUseByAlign(int nAlignGroup)
+        public static IntPtr ItemPropertyLimitUseByAlign(int nAlignGroup)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nAlignGroup);
             NWN.Internal.NativeFunctions.CallBuiltIn(672);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
         ///  Returns Item property limit use by class.  You must specify the class(es) who
         ///  are able to use this item(IP_CONST_CLASS_*).
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyLimitUseByClass(int nClass)
+        public static IntPtr ItemPropertyLimitUseByClass(int nClass)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nClass);
             NWN.Internal.NativeFunctions.CallBuiltIn(673);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
         ///  Returns Item property limit use by race.  You must specify the race(s) who are
         ///  allowed to use this item(IP_CONST_RACIALTYPE_*).
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyLimitUseByRace(int nRace)
+        public static IntPtr ItemPropertyLimitUseByRace(int nRace)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nRace);
             NWN.Internal.NativeFunctions.CallBuiltIn(674);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
         ///  Returns Item property limit use by specific alignment.  You must specify the
         ///  alignment(s) of those allowed to use the item(IP_CONST_ALIGNMENT_*).
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyLimitUseBySAlign(int nAlignment)
+        public static IntPtr ItemPropertyLimitUseBySAlign(int nAlignment)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nAlignment);
             NWN.Internal.NativeFunctions.CallBuiltIn(675);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
         ///  replace this function it does nothing.
         /// </summary>
-        public static NWN.ItemProperty BadBadReplaceMeThisDoesNothing()
+        public static IntPtr BadBadReplaceMeThisDoesNothing()
         {
             NWN.Internal.NativeFunctions.CallBuiltIn(676);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
         ///  Returns Item property vampiric regeneration.  You must specify the amount of
         ///  regeneration.  The regen amount must be an integer between 1 and 20.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyVampiricRegeneration(int nRegenAmount)
+        public static IntPtr ItemPropertyVampiricRegeneration(int nRegenAmount)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nRegenAmount);
             NWN.Internal.NativeFunctions.CallBuiltIn(677);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
         ///  Returns Item property Trap.  You must specify the trap level constant
         ///  (IP_CONST_TRAPSTRENGTH_*) and the trap type constant(IP_CONST_TRAPTYPE_*).
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyTrap(int nTrapLevel, int nTrapType)
+        public static IntPtr ItemPropertyTrap(int nTrapLevel, int nTrapType)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nTrapType);
             NWN.Internal.NativeFunctions.StackPushInteger(nTrapLevel);
             NWN.Internal.NativeFunctions.CallBuiltIn(678);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
         ///  Returns Item property true seeing.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyTrueSeeing()
+        public static IntPtr ItemPropertyTrueSeeing()
         {
             NWN.Internal.NativeFunctions.CallBuiltIn(679);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -8876,43 +8879,43 @@ namespace NWN
         ///  NOTE: These can only be applied to monster NATURAL weapons (ie. bite, claw,
         ///        gore, and slam).  IT WILL NOT WORK ON NORMAL WEAPONS.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyOnMonsterHitProperties(int nProperty, int nSpecial = 0)
+        public static IntPtr ItemPropertyOnMonsterHitProperties(int nProperty, int nSpecial = 0)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nSpecial);
             NWN.Internal.NativeFunctions.StackPushInteger(nProperty);
             NWN.Internal.NativeFunctions.CallBuiltIn(680);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
         ///  Returns Item property turn resistance.  You must specify the resistance bonus.
         ///  The bonus must be an integer between 1 and 50.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyTurnResistance(int nModifier)
+        public static IntPtr ItemPropertyTurnResistance(int nModifier)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nModifier);
             NWN.Internal.NativeFunctions.CallBuiltIn(681);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
         ///  Returns Item property Massive Critical.  You must specify the extra damage
         ///  constant(IP_CONST_DAMAGEBONUS_*) of the criticals.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyMassiveCritical(int nDamage)
+        public static IntPtr ItemPropertyMassiveCritical(int nDamage)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nDamage);
             NWN.Internal.NativeFunctions.CallBuiltIn(682);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
         ///  Returns Item property free action.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyFreeAction()
+        public static IntPtr ItemPropertyFreeAction()
         {
             NWN.Internal.NativeFunctions.CallBuiltIn(683);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -8921,11 +8924,11 @@ namespace NWN
         ///  NOTE: These can only be applied to monster NATURAL weapons (ie. bite, claw,
         ///        gore, and slam).  IT WILL NOT WORK ON NORMAL WEAPONS.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyMonsterDamage(int nDamage)
+        public static IntPtr ItemPropertyMonsterDamage(int nDamage)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nDamage);
             NWN.Internal.NativeFunctions.CallBuiltIn(684);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -8934,11 +8937,11 @@ namespace NWN
         ///  between 1 and 9.  By putting in a 3 it will mean the user is immune to all
         ///  3rd level and lower spells.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyImmunityToSpellLevel(int nLevel)
+        public static IntPtr ItemPropertyImmunityToSpellLevel(int nLevel)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nLevel);
             NWN.Internal.NativeFunctions.CallBuiltIn(685);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -8946,33 +8949,33 @@ namespace NWN
         ///  automatically use the zombie walk.  This will apply the special walk animation
         ///  to the user.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertySpecialWalk(int nWalkType = 0)
+        public static IntPtr ItemPropertySpecialWalk(int nWalkType = 0)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nWalkType);
             NWN.Internal.NativeFunctions.CallBuiltIn(686);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
         ///  Returns Item property healers kit.  You must specify the level of the kit.
         ///  The modifier must be an integer between 1 and 12.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyHealersKit(int nModifier)
+        public static IntPtr ItemPropertyHealersKit(int nModifier)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nModifier);
             NWN.Internal.NativeFunctions.CallBuiltIn(687);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
         ///  Returns Item property weight increase.  You must specify the weight increase
         ///  constant(IP_CONST_WEIGHTINCREASE_*).
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyWeightIncrease(int nWeight)
+        public static IntPtr ItemPropertyWeightIncrease(int nWeight)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nWeight);
             NWN.Internal.NativeFunctions.CallBuiltIn(688);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -8996,12 +8999,12 @@ namespace NWN
         ///  - nPercent - percentage of failure
         ///  - nSpellSchool - the school of spells affected.
         /// </summary>
-        public static NWN.Effect EffectSpellFailure(int nPercent = 100, int nSpellSchool = SPELL_SCHOOL_GENERAL)
+        public static IntPtr EffectSpellFailure(int nPercent = 100, int nSpellSchool = SPELL_SCHOOL_GENERAL)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nSpellSchool);
             NWN.Internal.NativeFunctions.StackPushInteger(nPercent);
             NWN.Internal.NativeFunctions.CallBuiltIn(690);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -9260,10 +9263,10 @@ namespace NWN
         ///  Returns an effect of type EFFECT_TYPE_ETHEREAL which works just like EffectSanctuary
         ///  except that the observers get no saving throw
         /// </summary>
-        public static NWN.Effect EffectEthereal()
+        public static IntPtr EffectEthereal()
         {
             NWN.Internal.NativeFunctions.CallBuiltIn(711);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -9528,20 +9531,20 @@ namespace NWN
         ///  when a successful strike is made, or (when applied to armor) is struck by an opponent.
         ///  - nSpell uses the IP_CONST_ONHIT_CASTSPELL_* constants
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyOnHitCastSpell(int nSpell, int nLevel)
+        public static IntPtr ItemPropertyOnHitCastSpell(int nSpell, int nLevel)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nLevel);
             NWN.Internal.NativeFunctions.StackPushInteger(nSpell);
             NWN.Internal.NativeFunctions.CallBuiltIn(733);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
         ///  Returns the SubType number of the item property. See the 2DA files for value definitions.
         /// </summary>
-        public static int GetItemPropertySubType(NWN.ItemProperty iProperty)
+        public static int GetItemPropertySubType(IntPtr iProperty)
         {
-            NWN.Internal.NativeFunctions.StackPushItemProperty(iProperty.Handle);
+            NWN.Internal.NativeFunctions.StackPushItemProperty(iProperty);
             NWN.Internal.NativeFunctions.CallBuiltIn(734);
             return NWN.Internal.NativeFunctions.StackPopInteger();
         }
@@ -9592,11 +9595,11 @@ namespace NWN
         ///  Creates a visual effect (ITEM_VISUAL_*) that may be applied to
         ///  melee weapons only.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyVisualEffect(int nEffect)
+        public static IntPtr ItemPropertyVisualEffect(int nEffect)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nEffect);
             NWN.Internal.NativeFunctions.CallBuiltIn(739);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -9754,10 +9757,10 @@ namespace NWN
         ///  PLEASE NOTE: This is an expensive function and may
         ///               degrade performance if used frequently.
         /// </summary>
-        public static int LineOfSightVector(NWN.Vector? vSource, NWN.Vector? vTarget)
+        public static int LineOfSightVector(Vector3? vSource, Vector3? vTarget)
         {
-            NWN.Internal.NativeFunctions.StackPushVector(vTarget.HasValue ? vTarget.Value : new NWN.Vector());
-            NWN.Internal.NativeFunctions.StackPushVector(vSource.HasValue ? vSource.Value : new NWN.Vector());
+            NWN.Internal.NativeFunctions.StackPushVector(vTarget.HasValue ? vTarget.Value : new Vector3());
+            NWN.Internal.NativeFunctions.StackPushVector(vSource.HasValue ? vSource.Value : new Vector3());
             NWN.Internal.NativeFunctions.CallBuiltIn(753);
             return NWN.Internal.NativeFunctions.StackPopInteger();
         }
@@ -9802,21 +9805,21 @@ namespace NWN
         ///  to pathfind through other creatures without bumping into them
         ///  for the duration of the effect.
         /// </summary>
-        public static NWN.Effect EffectCutsceneGhost()
+        public static IntPtr EffectCutsceneGhost()
         {
             NWN.Internal.NativeFunctions.CallBuiltIn(757);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
         ///  Creates an item property that offsets the effect on arcane spell failure
         ///  that a particular item has. Parameters come from the ITEM_PROP_ASF_* group.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyArcaneSpellFailure(int nModLevel)
+        public static IntPtr ItemPropertyArcaneSpellFailure(int nModLevel)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nModLevel);
             NWN.Internal.NativeFunctions.CallBuiltIn(758);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -9909,10 +9912,10 @@ namespace NWN
         ///  Returns an effect that when applied will paralyze the target's legs, rendering
         ///  them unable to walk but otherwise unpenalized. This effect cannot be resisted.
         /// </summary>
-        public static NWN.Effect EffectCutsceneImmobilize()
+        public static IntPtr EffectCutsceneImmobilize()
         {
             NWN.Internal.NativeFunctions.CallBuiltIn(767);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -9931,9 +9934,9 @@ namespace NWN
         /// <summary>
         ///  Returns the Cost Table number of the item property. See the 2DA files for value definitions.
         /// </summary>
-        public static int GetItemPropertyCostTable(NWN.ItemProperty iProp)
+        public static int GetItemPropertyCostTable(IntPtr iProp)
         {
-            NWN.Internal.NativeFunctions.StackPushItemProperty(iProp.Handle);
+            NWN.Internal.NativeFunctions.StackPushItemProperty(iProp);
             NWN.Internal.NativeFunctions.CallBuiltIn(769);
             return NWN.Internal.NativeFunctions.StackPopInteger();
         }
@@ -9942,9 +9945,9 @@ namespace NWN
         ///  Returns the Cost Table value (index of the cost table) of the item property.
         ///  See the 2DA files for value definitions.
         /// </summary>
-        public static int GetItemPropertyCostTableValue(NWN.ItemProperty iProp)
+        public static int GetItemPropertyCostTableValue(IntPtr iProp)
         {
-            NWN.Internal.NativeFunctions.StackPushItemProperty(iProp.Handle);
+            NWN.Internal.NativeFunctions.StackPushItemProperty(iProp);
             NWN.Internal.NativeFunctions.CallBuiltIn(770);
             return NWN.Internal.NativeFunctions.StackPopInteger();
         }
@@ -9952,9 +9955,9 @@ namespace NWN
         /// <summary>
         ///  Returns the Param1 number of the item property. See the 2DA files for value definitions.
         /// </summary>
-        public static int GetItemPropertyParam1(NWN.ItemProperty iProp)
+        public static int GetItemPropertyParam1(IntPtr iProp)
         {
-            NWN.Internal.NativeFunctions.StackPushItemProperty(iProp.Handle);
+            NWN.Internal.NativeFunctions.StackPushItemProperty(iProp);
             NWN.Internal.NativeFunctions.CallBuiltIn(771);
             return NWN.Internal.NativeFunctions.StackPopInteger();
         }
@@ -9962,9 +9965,9 @@ namespace NWN
         /// <summary>
         ///  Returns the Param1 value of the item property. See the 2DA files for value definitions.
         /// </summary>
-        public static int GetItemPropertyParam1Value(NWN.ItemProperty iProp)
+        public static int GetItemPropertyParam1Value(IntPtr iProp)
         {
-            NWN.Internal.NativeFunctions.StackPushItemProperty(iProp.Handle);
+            NWN.Internal.NativeFunctions.StackPushItemProperty(iProp);
             NWN.Internal.NativeFunctions.CallBuiltIn(772);
             return NWN.Internal.NativeFunctions.StackPopInteger();
         }
@@ -10554,14 +10557,14 @@ namespace NWN
         ///                            type specified will fire instead (as specified in the
         ///                            traps.2da).
         /// </summary>
-        public static uint CreateTrapAtLocation(int nTrapType, NWN.Location lLocation, float fSize = 2.0f, string sTag = "", int nFaction = STANDARD_FACTION_HOSTILE, string sOnDisarmScript = "", string sOnTrapTriggeredScript = "")
+        public static uint CreateTrapAtLocation(int nTrapType, IntPtr lLocation, float fSize = 2.0f, string sTag = "", int nFaction = STANDARD_FACTION_HOSTILE, string sOnDisarmScript = "", string sOnTrapTriggeredScript = "")
         {
             NWN.Internal.NativeFunctions.StackPushStringUTF8(sOnTrapTriggeredScript);
             NWN.Internal.NativeFunctions.StackPushStringUTF8(sOnDisarmScript);
             NWN.Internal.NativeFunctions.StackPushInteger(nFaction);
             NWN.Internal.NativeFunctions.StackPushStringUTF8(sTag);
             NWN.Internal.NativeFunctions.StackPushFloat(fSize);
-            NWN.Internal.NativeFunctions.StackPushLocation(lLocation.Handle);
+            NWN.Internal.NativeFunctions.StackPushLocation(lLocation);
             NWN.Internal.NativeFunctions.StackPushInteger(nTrapType);
             NWN.Internal.NativeFunctions.CallBuiltIn(809);
             return NWN.Internal.NativeFunctions.StackPopObject();
@@ -11102,11 +11105,11 @@ namespace NWN
         ///  - nMasterialType: The Material Type should be a positive integer between 0 and 77 (see iprp_matcost.2da).
         ///  Note: The Material Type property will only affect the cost of the item if you modify the cost in the iprp_matcost.2da.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyMaterial(int nMaterialType)
+        public static IntPtr ItemPropertyMaterial(int nMaterialType)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nMaterialType);
             NWN.Internal.NativeFunctions.CallBuiltIn(845);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -11115,11 +11118,11 @@ namespace NWN
         ///               IP_CONST_QUALITY_*
         ///  Note: The quality property will only affect the cost of the item if you modify the cost in the iprp_qualcost.2da.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyQuality(int nQuality)
+        public static IntPtr ItemPropertyQuality(int nQuality)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nQuality);
             NWN.Internal.NativeFunctions.CallBuiltIn(846);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -11128,11 +11131,11 @@ namespace NWN
         ///               IP_CONST_ADDITIONAL_*
         ///  Note: The additional property only affects the cost of the item if you modify the cost in the iprp_addcost.2da.
         /// </summary>
-        public static NWN.ItemProperty ItemPropertyAdditional(int nAdditionalProperty)
+        public static IntPtr ItemPropertyAdditional(int nAdditionalProperty)
         {
             NWN.Internal.NativeFunctions.StackPushInteger(nAdditionalProperty);
             NWN.Internal.NativeFunctions.CallBuiltIn(847);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
@@ -11154,9 +11157,9 @@ namespace NWN
         ///  Returns the string tag set for the provided effect.
         ///  - If no tag has been set, returns an empty string.
         /// </summary>
-        public static string GetEffectTag(NWN.Effect eEffect)
+        public static string GetEffectTag(IntPtr eEffect)
         {
-            NWN.Internal.NativeFunctions.StackPushEffect(eEffect.Handle);
+            NWN.Internal.NativeFunctions.StackPushEffect(eEffect);
             NWN.Internal.NativeFunctions.CallBuiltIn(849);
             return NWN.Internal.NativeFunctions.StackPopStringUTF8();
         }
@@ -11165,12 +11168,12 @@ namespace NWN
         ///  Tags the effect with the provided string.
         ///  - Any other tags in the link will be overwritten.
         /// </summary>
-        public static NWN.Effect TagEffect(NWN.Effect eEffect, string sNewTag)
+        public static IntPtr TagEffect(IntPtr eEffect, string sNewTag)
         {
             NWN.Internal.NativeFunctions.StackPushStringUTF8(sNewTag);
-            NWN.Internal.NativeFunctions.StackPushEffect(eEffect.Handle);
+            NWN.Internal.NativeFunctions.StackPushEffect(eEffect);
             NWN.Internal.NativeFunctions.CallBuiltIn(850);
-            return new NWN.Effect(NWN.Internal.NativeFunctions.StackPopEffect());
+            return NWN.Internal.NativeFunctions.StackPopEffect();
         }
 
         /// <summary>
@@ -11178,9 +11181,9 @@ namespace NWN
         ///  - If not created by a creature, returns 0.
         ///  - If created by a spell-like ability, returns 0.
         /// </summary>
-        public static int GetEffectCasterLevel(NWN.Effect eEffect)
+        public static int GetEffectCasterLevel(IntPtr eEffect)
         {
-            NWN.Internal.NativeFunctions.StackPushEffect(eEffect.Handle);
+            NWN.Internal.NativeFunctions.StackPushEffect(eEffect);
             NWN.Internal.NativeFunctions.CallBuiltIn(851);
             return NWN.Internal.NativeFunctions.StackPopInteger();
         }
@@ -11189,9 +11192,9 @@ namespace NWN
         ///  Returns the total duration of the effect in seconds.
         ///  - Returns 0 if the duration type of the effect is not DURATION_TYPE_TEMPORARY.
         /// </summary>
-        public static int GetEffectDuration(NWN.Effect eEffect)
+        public static int GetEffectDuration(IntPtr eEffect)
         {
-            NWN.Internal.NativeFunctions.StackPushEffect(eEffect.Handle);
+            NWN.Internal.NativeFunctions.StackPushEffect(eEffect);
             NWN.Internal.NativeFunctions.CallBuiltIn(852);
             return NWN.Internal.NativeFunctions.StackPopInteger();
         }
@@ -11200,9 +11203,9 @@ namespace NWN
         ///  Returns the remaining duration of the effect in seconds.
         ///  - Returns 0 if the duration type of the effect is not DURATION_TYPE_TEMPORARY.
         /// </summary>
-        public static int GetEffectDurationRemaining(NWN.Effect eEffect)
+        public static int GetEffectDurationRemaining(IntPtr eEffect)
         {
-            NWN.Internal.NativeFunctions.StackPushEffect(eEffect.Handle);
+            NWN.Internal.NativeFunctions.StackPushEffect(eEffect);
             NWN.Internal.NativeFunctions.CallBuiltIn(853);
             return NWN.Internal.NativeFunctions.StackPopInteger();
         }
@@ -11211,9 +11214,9 @@ namespace NWN
         ///  Returns the string tag set for the provided item property.
         ///  - If no tag has been set, returns an empty string.
         /// </summary>
-        public static string GetItemPropertyTag(NWN.ItemProperty nProperty)
+        public static string GetItemPropertyTag(IntPtr nProperty)
         {
-            NWN.Internal.NativeFunctions.StackPushItemProperty(nProperty.Handle);
+            NWN.Internal.NativeFunctions.StackPushItemProperty(nProperty);
             NWN.Internal.NativeFunctions.CallBuiltIn(854);
             return NWN.Internal.NativeFunctions.StackPopStringUTF8();
         }
@@ -11222,21 +11225,21 @@ namespace NWN
         ///  Tags the item property with the provided string.
         ///  - Any tags currently set on the item property will be overwritten.
         /// </summary>
-        public static NWN.ItemProperty TagItemProperty(NWN.ItemProperty nProperty, string sNewTag)
+        public static IntPtr TagItemProperty(IntPtr nProperty, string sNewTag)
         {
             NWN.Internal.NativeFunctions.StackPushStringUTF8(sNewTag);
-            NWN.Internal.NativeFunctions.StackPushItemProperty(nProperty.Handle);
+            NWN.Internal.NativeFunctions.StackPushItemProperty(nProperty);
             NWN.Internal.NativeFunctions.CallBuiltIn(855);
-            return new NWN.ItemProperty(NWN.Internal.NativeFunctions.StackPopItemProperty());
+            return NWN.Internal.NativeFunctions.StackPopItemProperty();
         }
 
         /// <summary>
         ///  Returns the total duration of the item property in seconds.
         ///  - Returns 0 if the duration type of the item property is not DURATION_TYPE_TEMPORARY.
         /// </summary>
-        public static int GetItemPropertyDuration(NWN.ItemProperty nProperty)
+        public static int GetItemPropertyDuration(IntPtr nProperty)
         {
-            NWN.Internal.NativeFunctions.StackPushItemProperty(nProperty.Handle);
+            NWN.Internal.NativeFunctions.StackPushItemProperty(nProperty);
             NWN.Internal.NativeFunctions.CallBuiltIn(856);
             return NWN.Internal.NativeFunctions.StackPopInteger();
         }
@@ -11245,9 +11248,9 @@ namespace NWN
         ///  Returns the remaining duration of the item property in seconds.
         ///  - Returns 0 if the duration type of the item property is not DURATION_TYPE_TEMPORARY.
         /// </summary>
-        public static int GetItemPropertyDurationRemaining(NWN.ItemProperty nProperty)
+        public static int GetItemPropertyDurationRemaining(IntPtr nProperty)
         {
-            NWN.Internal.NativeFunctions.StackPushItemProperty(nProperty.Handle);
+            NWN.Internal.NativeFunctions.StackPushItemProperty(nProperty);
             NWN.Internal.NativeFunctions.CallBuiltIn(857);
             return NWN.Internal.NativeFunctions.StackPopInteger();
         }
@@ -11452,9 +11455,9 @@ namespace NWN
         ///  equivalent to the walkmesh type).
         ///  Returns 0 if the location is invalid or has no surface type.
         /// </summary>
-        public static int GetSurfaceMaterial(NWN.Location at)
+        public static int GetSurfaceMaterial(IntPtr at)
         {
-            NWN.Internal.NativeFunctions.StackPushLocation(at.Handle);
+            NWN.Internal.NativeFunctions.StackPushLocation(at);
             NWN.Internal.NativeFunctions.CallBuiltIn(870);
             return NWN.Internal.NativeFunctions.StackPopInteger();
         }
@@ -11463,9 +11466,9 @@ namespace NWN
         ///  Returns the z-offset at which the walkmesh is at the given location.
         ///  Returns -6.0 for invalid locations.
         /// </summary>
-        public static float GetGroundHeight(NWN.Location at)
+        public static float GetGroundHeight(IntPtr at)
         {
-            NWN.Internal.NativeFunctions.StackPushLocation(at.Handle);
+            NWN.Internal.NativeFunctions.StackPushLocation(at);
             NWN.Internal.NativeFunctions.CallBuiltIn(871);
             return NWN.Internal.NativeFunctions.StackPopFloat();
         }

--- a/src/Native/NativeTypes.cs
+++ b/src/Native/NativeTypes.cs
@@ -3,21 +3,6 @@ using System.Runtime.InteropServices;
 
 namespace NWN
 {
-    [StructLayout(LayoutKind.Sequential)]
-    public struct Vector
-    {
-        public float x;
-        public float y;
-        public float z;
-
-        public Vector(float x = 0.0f, float y = 0.0f, float z = 0.0f)
-        {
-            this.x = x;
-            this.y = y;
-            this.z = z;
-        }
-    }
-
     public class Effect
     {
         public IntPtr Handle;

--- a/src/Native/NativeTypes.cs
+++ b/src/Native/NativeTypes.cs
@@ -23,6 +23,9 @@ namespace NWN
         public IntPtr Handle;
         public Effect(IntPtr handle) { Handle = handle; }
         ~Effect() { Internal.NativeFunctions.FreeEffect(Handle); }
+
+        public static implicit operator IntPtr(Effect effect) => effect.Handle;
+        public static implicit operator Effect(IntPtr intPtr) => new Effect(intPtr);
     }
 
     public class Event
@@ -30,6 +33,9 @@ namespace NWN
         public IntPtr Handle;
         public Event(IntPtr handle) { Handle = handle; }
         ~Event() { Internal.NativeFunctions.FreeEvent(Handle); }
+
+        public static implicit operator IntPtr(Event effect) => effect.Handle;
+        public static implicit operator Event(IntPtr intPtr) => new Event(intPtr);
     }
 
     public class Location
@@ -37,6 +43,9 @@ namespace NWN
         public IntPtr Handle;
         public Location(IntPtr handle) { Handle = handle; }
         ~Location() { Internal.NativeFunctions.FreeLocation(Handle); }
+
+        public static implicit operator IntPtr(Location effect) => effect.Handle;
+        public static implicit operator Location(IntPtr intPtr) => new Location(intPtr);
     }
 
     public class Talent
@@ -44,6 +53,9 @@ namespace NWN
         public IntPtr Handle;
         public Talent(IntPtr handle) { Handle = handle; }
         ~Talent() { Internal.NativeFunctions.FreeTalent(Handle); }
+
+        public static implicit operator IntPtr(Talent effect) => effect.Handle;
+        public static implicit operator Talent(IntPtr intPtr) => new Talent(intPtr);
     }
 
     public class ItemProperty
@@ -51,6 +63,9 @@ namespace NWN
         public IntPtr Handle;
         public ItemProperty(IntPtr handle) { Handle = handle; }
         ~ItemProperty() { Internal.NativeFunctions.FreeItemProperty(Handle); }
+
+        public static implicit operator IntPtr(ItemProperty effect) => effect.Handle;
+        public static implicit operator ItemProperty(IntPtr intPtr) => new ItemProperty(intPtr);
     }
 
     public delegate void ActionDelegate();


### PR DESCRIPTION
Changed existing native functions to use int pointers to allow custom implementations of managed types.

The existing native types have new implicit conversions for those who still want a basic implementation.