### PR TITLE
Use interface implementation for bootstrap bindings

### DIFF
--- a/src/Internal/IGameManager.cs
+++ b/src/Internal/IGameManager.cs
@@ -1,0 +1,15 @@
+namespace NWN
+{
+  public interface IGameManager
+  {
+    uint ObjectSelf { get; }
+
+    void OnMainLoop(ulong frame);
+    int OnRunScript(string script, uint oidSelf);
+    void OnClosure(ulong eid, uint oidSelf);
+
+    void ClosureAssignCommand(uint obj, ActionDelegate func);
+    void ClosureDelayCommand(uint obj, float duration, ActionDelegate func);
+    void ClosureActionDoCommand(uint obj, ActionDelegate func);
+  }
+}

--- a/src/Native/Functions.cs
+++ b/src/Native/Functions.cs
@@ -28,7 +28,7 @@ namespace NWN
         /// </summary>
         public static void DelayCommand(float fSeconds, ActionDelegate aActionToDelay)
         {
-            Internal.ManagedFunctions.ClosureDelayCommand(Internal.ObjectSelf(), fSeconds, aActionToDelay);
+            Internal.ManagedFunctions.ClosureDelayCommand(Internal.ObjectSelf, fSeconds, aActionToDelay);
         }
 
         /// <summary>
@@ -36,7 +36,7 @@ namespace NWN
         /// </summary>
         public static void ActionDoCommand(ActionDelegate aActionToDo)
         {
-            Internal.ManagedFunctions.ClosureActionDoCommand(Internal.ObjectSelf(), aActionToDo);
+            Internal.ManagedFunctions.ClosureActionDoCommand(Internal.ObjectSelf, aActionToDo);
         }
 
         /// <summary>


### PR DESCRIPTION
We should ensure that the derived bootstrap class defines all handles to prevent bad things from happening. An interface seems like the best approach for this.