### PR TITLE
Move core functions and constants to NWN.Core namespace

### DIFF
--- a/NWN.Core.csproj
+++ b/NWN.Core.csproj
@@ -3,7 +3,6 @@
         <TargetFramework>netcoreapp3.1</TargetFramework>
         <LangVersion>8.0</LangVersion>
         <PackageId>NWN.Core</PackageId>
-        <RootNamespace>NWN</RootNamespace>
         <Authors>NWN-dotnet</Authors>
         <Nullable>enable</Nullable>
         <PackageTags>Neverwinter Nights;NWN;</PackageTags>

--- a/src/Internal/IGameManager.cs
+++ b/src/Internal/IGameManager.cs
@@ -1,4 +1,4 @@
-namespace NWN
+namespace NWN.Core
 {
   public interface IGameManager
   {

--- a/src/Internal/Internal.Managed.cs
+++ b/src/Internal/Internal.Managed.cs
@@ -1,4 +1,4 @@
-namespace NWN
+namespace NWN.Core
 {
     public static partial class Internal
     {

--- a/src/Internal/Internal.Native.Events.cs
+++ b/src/Internal/Internal.Native.Events.cs
@@ -1,6 +1,6 @@
 using System.Runtime.InteropServices;
 
-namespace NWN
+namespace NWN.Core
 {
     public static partial class Internal
     {

--- a/src/Internal/Internal.Native.cs
+++ b/src/Internal/Internal.Native.cs
@@ -3,7 +3,7 @@ using System.Numerics;
 using System.Runtime.InteropServices;
 using System.Security;
 
-namespace NWN
+namespace NWN.Core
 {
     public static partial class Internal
     {

--- a/src/Internal/Internal.cs
+++ b/src/Internal/Internal.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
 
-namespace NWN
+namespace NWN.Core
 {
     public static partial class Internal
     {
@@ -14,7 +14,7 @@ namespace NWN
         public static ManagedHandles ManagedFunctions;
         private static NativeEventHandles eventHandles;
 
-        public static int Bootstrap(IntPtr nativeHandlesPtr, int nativeHandlesLength, IGameManager gameManager)
+        public static int Init(IntPtr nativeHandlesPtr, int nativeHandlesLength, IGameManager gameManager)
         {
             Internal.gameManager = gameManager;
 

--- a/src/NWNX/AdminPlugin.cs
+++ b/src/NWNX/AdminPlugin.cs
@@ -1,6 +1,4 @@
-using NWN;
-
-namespace NWNX
+namespace NWN.Core.NWNX
 {
     [NWNXPlugin(NWNX_Administration)]
     public class AdminPlugin

--- a/src/NWNX/AppearancePlugin.cs
+++ b/src/NWNX/AppearancePlugin.cs
@@ -1,6 +1,4 @@
-using NWN;
-
-namespace NWNX
+namespace NWN.Core.NWNX
 {
     [NWNXPlugin(NWNX_Appearance)]
     public class AppearancePlugin

--- a/src/NWNX/AreaPlugin.cs
+++ b/src/NWNX/AreaPlugin.cs
@@ -1,6 +1,4 @@
-using NWN;
-
-namespace NWNX
+namespace NWN.Core.NWNX
 {
     [NWNXPlugin(NWNX_Area)]
     public class AreaPlugin

--- a/src/NWNX/ChatPlugin.cs
+++ b/src/NWNX/ChatPlugin.cs
@@ -1,6 +1,4 @@
-using NWN;
-
-namespace NWNX
+namespace NWN.Core.NWNX
 {
     [NWNXPlugin(NWNX_Chat)]
     public class ChatPlugin

--- a/src/NWNX/CreaturePlugin.cs
+++ b/src/NWNX/CreaturePlugin.cs
@@ -1,6 +1,4 @@
-using NWN;
-
-namespace NWNX
+namespace NWN.Core.NWNX
 {
     [NWNXPlugin(NWNX_Creature)]
     public class CreaturePlugin

--- a/src/NWNX/DamagePlugin.cs
+++ b/src/NWNX/DamagePlugin.cs
@@ -1,6 +1,4 @@
-using NWN;
-
-namespace NWNX
+namespace NWN.Core.NWNX
 {
     [NWNXPlugin(NWNX_Damage)]
     public class DamagePlugin

--- a/src/NWNX/DataPlugin.cs
+++ b/src/NWNX/DataPlugin.cs
@@ -1,6 +1,4 @@
-using NWN;
-
-namespace NWNX
+namespace NWN.Core.NWNX
 {
     [NWNXPlugin(NWNX_Data)]
     public class DataPlugin

--- a/src/NWNX/DialogPlugin.cs
+++ b/src/NWNX/DialogPlugin.cs
@@ -1,6 +1,4 @@
-using NWN;
-
-namespace NWNX
+namespace NWN.Core.NWNX
 {
     [NWNXPlugin(NWNX_Dialog)]
     public class DialogPlugin

--- a/src/NWNX/EffectPlugin.cs
+++ b/src/NWNX/EffectPlugin.cs
@@ -1,6 +1,4 @@
-using NWN;
-
-namespace NWNX
+namespace NWN.Core.NWNX
 {
     [NWNXPlugin(NWNX_Effect)]
     public class EffectPlugin

--- a/src/NWNX/ElcPlugin.cs
+++ b/src/NWNX/ElcPlugin.cs
@@ -1,6 +1,4 @@
-using NWN;
-
-namespace NWNX
+namespace NWN.Core.NWNX
 {
     [NWNXPlugin(NWNX_ELC)]
     public class ElcPlugin

--- a/src/NWNX/EncounterPlugin.cs
+++ b/src/NWNX/EncounterPlugin.cs
@@ -1,6 +1,4 @@
-using NWN;
-
-namespace NWNX
+namespace NWN.Core.NWNX
 {
     [NWNXPlugin(NWNX_Encounter)]
     public class EncounterPlugin

--- a/src/NWNX/EventsPlugin.cs
+++ b/src/NWNX/EventsPlugin.cs
@@ -1,6 +1,4 @@
-using NWN;
-
-namespace NWNX
+namespace NWN.Core.NWNX
 {
     [NWNXPlugin(NWNX_Events)]
     public class EventsPlugin

--- a/src/NWNX/FeedbackPlugin.cs
+++ b/src/NWNX/FeedbackPlugin.cs
@@ -1,6 +1,4 @@
-using NWN;
-
-namespace NWNX
+namespace NWN.Core.NWNX
 {
     [NWNXPlugin(NWNX_Feedback)]
     public class FeedbackPlugin

--- a/src/NWNX/ItemPlugin.cs
+++ b/src/NWNX/ItemPlugin.cs
@@ -1,6 +1,4 @@
-using NWN;
-
-namespace NWNX
+namespace NWN.Core.NWNX
 {
     [NWNXPlugin(NWNX_Item)]
     public class ItemPlugin

--- a/src/NWNX/ItempropPlugin.cs
+++ b/src/NWNX/ItempropPlugin.cs
@@ -1,6 +1,4 @@
-using NWN;
-
-namespace NWNX
+namespace NWN.Core.NWNX
 {
     [NWNXPlugin(NWNX_ItemProperty)]
     public class ItempropPlugin

--- a/src/NWNX/LuaPlugin.cs
+++ b/src/NWNX/LuaPlugin.cs
@@ -1,6 +1,4 @@
-using NWN;
-
-namespace NWNX
+namespace NWN.Core.NWNX
 {
     [NWNXPlugin(NWNX_Lua)]
     public class LuaPlugin

--- a/src/NWNX/NWNXPluginAttribute.cs
+++ b/src/NWNX/NWNXPluginAttribute.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace NWNX
+namespace NWN.Core.NWNX
 {
   [AttributeUsage(AttributeTargets.Class)]
   public class NWNXPluginAttribute : Attribute

--- a/src/NWNX/ObjectPlugin.cs
+++ b/src/NWNX/ObjectPlugin.cs
@@ -1,6 +1,4 @@
-using NWN;
-
-namespace NWNX
+namespace NWN.Core.NWNX
 {
     [NWNXPlugin(NWNX_Object)]
     public class ObjectPlugin

--- a/src/NWNX/PlayerPlugin.cs
+++ b/src/NWNX/PlayerPlugin.cs
@@ -1,6 +1,4 @@
-using NWN;
-
-namespace NWNX
+namespace NWN.Core.NWNX
 {
     [NWNXPlugin(NWNX_Player)]
     public class PlayerPlugin

--- a/src/NWNX/ProfilerPlugin.cs
+++ b/src/NWNX/ProfilerPlugin.cs
@@ -1,6 +1,4 @@
-using NWN;
-
-namespace NWNX
+namespace NWN.Core.NWNX
 {
     [NWNXPlugin(NWNX_Profiler)]
     public class ProfilerPlugin

--- a/src/NWNX/RegexPlugin.cs
+++ b/src/NWNX/RegexPlugin.cs
@@ -1,6 +1,4 @@
-using NWN;
-
-namespace NWNX
+namespace NWN.Core.NWNX
 {
     [NWNXPlugin(NWNX_Regex)]
     public class RegexPlugin

--- a/src/NWNX/RenamePlugin.cs
+++ b/src/NWNX/RenamePlugin.cs
@@ -1,6 +1,4 @@
-using NWN;
-
-namespace NWNX
+namespace NWN.Core.NWNX
 {
     [NWNXPlugin(NWNX_Rename)]
     public class RenamePlugin

--- a/src/NWNX/RevealPlugin.cs
+++ b/src/NWNX/RevealPlugin.cs
@@ -1,6 +1,4 @@
-using NWN;
-
-namespace NWNX
+namespace NWN.Core.NWNX
 {
     [NWNXPlugin(NWNX_Reveal)]
     public class RevealPlugin

--- a/src/NWNX/RubyPlugin.cs
+++ b/src/NWNX/RubyPlugin.cs
@@ -1,6 +1,4 @@
-using NWN;
-
-namespace NWNX
+namespace NWN.Core.NWNX
 {
     [NWNXPlugin(NWNX_Ruby)]
     public class RubyPlugin

--- a/src/NWNX/SkillranksPlugin.cs
+++ b/src/NWNX/SkillranksPlugin.cs
@@ -1,6 +1,4 @@
-using NWN;
-
-namespace NWNX
+namespace NWN.Core.NWNX
 {
     [NWNXPlugin(NWNX_SkillRanks)]
     public class SkillranksPlugin

--- a/src/NWNX/SpellcheckPlugin.cs
+++ b/src/NWNX/SpellcheckPlugin.cs
@@ -1,6 +1,4 @@
-using NWN;
-
-namespace NWNX
+namespace NWN.Core.NWNX
 {
     [NWNXPlugin(NWNX_SpellChecker)]
     public class SpellcheckPlugin

--- a/src/NWNX/SqlPlugin.cs
+++ b/src/NWNX/SqlPlugin.cs
@@ -1,6 +1,4 @@
-using NWN;
-
-namespace NWNX
+namespace NWN.Core.NWNX
 {
     [NWNXPlugin(NWNX_SQL)]
     public class SqlPlugin

--- a/src/NWNX/TimePlugin.cs
+++ b/src/NWNX/TimePlugin.cs
@@ -1,6 +1,4 @@
-using NWN;
-
-namespace NWNX
+namespace NWN.Core.NWNX
 {
     [NWNXPlugin(NWNX_Time)]
     public class TimePlugin

--- a/src/NWNX/UtilPlugin.cs
+++ b/src/NWNX/UtilPlugin.cs
@@ -1,6 +1,4 @@
-using NWN;
-
-namespace NWNX
+namespace NWN.Core.NWNX
 {
     [NWNXPlugin(NWNX_Util)]
     public class UtilPlugin

--- a/src/NWNX/VisibilityPlugin.cs
+++ b/src/NWNX/VisibilityPlugin.cs
@@ -1,6 +1,4 @@
-using NWN;
-
-namespace NWNX
+namespace NWN.Core.NWNX
 {
     [NWNXPlugin(NWNX_Visibility)]
     public class VisibilityPlugin

--- a/src/NWNX/WeaponPlugin.cs
+++ b/src/NWNX/WeaponPlugin.cs
@@ -1,6 +1,4 @@
-using NWN;
-
-namespace NWNX
+namespace NWN.Core.NWNX
 {
     [NWNXPlugin(NWNX_Weapon)]
     public class WeaponPlugin

--- a/src/NWNX/WebhookPlugin.cs
+++ b/src/NWNX/WebhookPlugin.cs
@@ -1,6 +1,4 @@
-using NWN;
-
-namespace NWNX
+namespace NWN.Core.NWNX
 {
     [NWNXPlugin(NWNX_WebHook)]
     public class WebhookPlugin

--- a/src/Native/Constants.cs
+++ b/src/Native/Constants.cs
@@ -1,4 +1,4 @@
-namespace NWN
+namespace NWN.Core
 {
     public static partial class NWScript
     {

--- a/src/Native/Functions.cs
+++ b/src/Native/Functions.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Numerics;
 
-namespace NWN
+namespace NWN.Core
 {
     public static partial class NWScript
     {

--- a/src/Native/NativeTypes.cs
+++ b/src/Native/NativeTypes.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace NWN
+namespace NWN.Core
 {
     public class Effect
     {


### PR DESCRIPTION
On NWNX's side, the bootstrap call points to `NWN.Internal.Bootstrap`.

`NWN.Core` does not implement this bootstrap logic, so we should free up the `NWN.*` namespace to be implemented by libraries and templates.