### PR TITLE
Split IGameManager interface to make event handlers optional.

### DIFF
--- a/src/Core/CoreGameManager.cs
+++ b/src/Core/CoreGameManager.cs
@@ -6,7 +6,7 @@ namespace NWN.Core
   /// <summary>
   /// Simple GameManager implementation. Used by default if no manager is specified during bootstrap.
   /// </summary>
-  public class CoreGameManager : IGameManager
+  public class CoreGameManager : ICoreFunctionHandler, ICoreEventHandler
   {
     // Hook-able Events
     public delegate void ServerLoopEvent(ulong frame);
@@ -27,15 +27,15 @@ namespace NWN.Core
     private uint objectSelf = ObjectInvalid;
 
     // Interface Implementations
-    uint IGameManager.ObjectSelf => objectSelf;
+    uint ICoreFunctionHandler.ObjectSelf => objectSelf;
 
-    void IGameManager.OnMainLoop(ulong frame)
+    void ICoreEventHandler.OnMainLoop(ulong frame)
         => OnServerLoop?.Invoke(frame);
 
-    void IGameManager.OnSignal(string signal)
+    void ICoreEventHandler.OnSignal(string signal)
         => OnSignal?.Invoke(signal);
 
-    int IGameManager.OnRunScript(string script, uint oidSelf)
+    int ICoreEventHandler.OnRunScript(string script, uint oidSelf)
     {
       int retVal = -1;
       objectSelf = oidSelf;
@@ -55,7 +55,7 @@ namespace NWN.Core
       return retVal;
     }
 
-    void IGameManager.OnClosure(ulong eid, uint oidSelf)
+    void ICoreEventHandler.OnClosure(ulong eid, uint oidSelf)
     {
       uint old = objectSelf;
       objectSelf = oidSelf;
@@ -73,7 +73,7 @@ namespace NWN.Core
       objectSelf = old;
     }
 
-    void IGameManager.ClosureAssignCommand(uint obj, ActionDelegate func)
+    void ICoreFunctionHandler.ClosureAssignCommand(uint obj, ActionDelegate func)
     {
       if (VM.ClosureAssignCommand(obj, nextEventId) != 0)
       {
@@ -81,7 +81,7 @@ namespace NWN.Core
       }
     }
 
-    void IGameManager.ClosureDelayCommand(uint obj, float duration, ActionDelegate func)
+    void ICoreFunctionHandler.ClosureDelayCommand(uint obj, float duration, ActionDelegate func)
     {
       if (VM.ClosureDelayCommand(obj, duration, nextEventId) != 0)
       {
@@ -89,7 +89,7 @@ namespace NWN.Core
       }
     }
 
-    void IGameManager.ClosureActionDoCommand(uint obj, ActionDelegate func)
+    void ICoreFunctionHandler.ClosureActionDoCommand(uint obj, ActionDelegate func)
     {
       if (VM.ClosureActionDoCommand(obj, nextEventId) != 0)
       {

--- a/src/Core/ICoreEventHandler.cs
+++ b/src/Core/ICoreEventHandler.cs
@@ -1,0 +1,34 @@
+namespace NWN.Core
+{
+  public interface ICoreEventHandler
+  {
+    /// <summary>
+    /// Called once every server update (loop).
+    /// </summary>
+    void OnMainLoop(ulong frame);
+
+    /// <summary>
+    /// Called every time the virtual machine will execute a script.
+    /// </summary>
+    /// <param name="script">The script invoked from the VM.</param>
+    /// <param name="oidSelf">The current object.</param>
+    /// <returns>-1: Not handled. If the script resource (ncs) is defined in the module, it will now be executed.<br/>
+    /// 0: FALSE/Handled - For conditional scripts, sets the result to FALSE. If the script resource (ncs) is defined in the module, it will not be executed.<br/>
+    /// 1: TRUE - For conditional scripts, sets the result to TRUE. If the script resource (ncs) is defined in the module, it will not be executed.</returns>
+    int OnRunScript(string script, uint oidSelf);
+
+    /// <summary>
+    /// Called during processing of closure based commands and other actions that happen at a later time.
+    /// </summary>
+    /// <param name="eid">The closure's unique event ID.</param>
+    /// <param name="oidSelf">The current object.</param>
+    void OnClosure(ulong eid, uint oidSelf);
+
+    /// <summary>
+    /// Called when a significant server event occurs (Startup/Shutdown).
+    /// </summary>
+    /// <param name="signal">"ON_MODULE_LOAD_FINISH" - Called just before the OnModuleLoad event. Perform any init requiring NWScript usage here.<br/>
+    /// "ON_DESTROY_SERVER" - Called just before the server will be shutdown. Perform any cleanup/flushing here.</param>
+    void OnSignal(string signal);
+  }
+}

--- a/src/Core/ICoreFunctionHandler.cs
+++ b/src/Core/ICoreFunctionHandler.cs
@@ -1,0 +1,11 @@
+namespace NWN.Core
+{
+  public interface ICoreFunctionHandler
+  {
+    uint ObjectSelf { get; }
+
+    void ClosureAssignCommand(uint obj, ActionDelegate func);
+    void ClosureDelayCommand(uint obj, float duration, ActionDelegate func);
+    void ClosureActionDoCommand(uint obj, ActionDelegate func);
+  }
+}

--- a/src/Core/IGameManager.cs
+++ b/src/Core/IGameManager.cs
@@ -1,40 +1,9 @@
+using System;
+
 namespace NWN.Core
 {
-  public interface IGameManager
-  {
-    uint ObjectSelf { get; }
-
-    /// <summary>
-    /// Called once every server update (loop).
-    /// </summary>
-    void OnMainLoop(ulong frame);
-
-    /// <summary>
-    /// Called every time the virtual machine will execute a script.
-    /// </summary>
-    /// <param name="script">The script invoked from the VM.</param>
-    /// <param name="oidSelf">The current object.</param>
-    /// <returns>-1: Not handled. If the script resource (ncs) is defined in the module, it will now be executed.<br/>
-    /// 0: FALSE/Handled - For conditional scripts, sets the result to FALSE. If the script resource (ncs) is defined in the module, it will not be executed.<br/>
-    /// 1: TRUE - For conditional scripts, sets the result to TRUE. If the script resource (ncs) is defined in the module, it will not be executed.</returns>
-    int OnRunScript(string script, uint oidSelf);
-
-    /// <summary>
-    /// Called during processing of closure based commands and other actions that happen at a later time.
-    /// </summary>
-    /// <param name="eid">The closure's unique event ID.</param>
-    /// <param name="oidSelf">The current object.</param>
-    void OnClosure(ulong eid, uint oidSelf);
-
-    /// <summary>
-    /// Called when a significant server event occurs (Startup/Shutdown).
-    /// </summary>
-    /// <param name="signal">"ON_MODULE_LOAD_FINISH" - Called just before the OnModuleLoad event. Perform any init requiring NWScript usage here.<br/>
-    /// "ON_DESTROY_SERVER" - Called just before the server will be shutdown. Perform any cleanup/flushing here.</param>
-    void OnSignal(string signal);
-
-    void ClosureAssignCommand(uint obj, ActionDelegate func);
-    void ClosureDelayCommand(uint obj, float duration, ActionDelegate func);
-    void ClosureActionDoCommand(uint obj, ActionDelegate func);
-  }
+  [Obsolete("IGameManager has been split into two interfaces to make event registration optional.\n" +
+    "Consider implementing ICoreEventHandler/ICoreFunctionHandler instead.\n" +
+    "IGameManager will be removed in a future release.")]
+  public interface IGameManager : ICoreEventHandler, ICoreFunctionHandler {}
 }

--- a/src/NWN/NWScript.cs
+++ b/src/NWN/NWScript.cs
@@ -6,7 +6,7 @@ namespace NWN.Core
   public static class NWScript
   {
     public const uint OBJECT_INVALID = 0x7F000000;
-    public static uint OBJECT_SELF => NWNCore.GameManager.ObjectSelf;
+    public static uint OBJECT_SELF => NWNCore.FunctionHandler.ObjectSelf;
     public const int ENGINE_NUM_STRUCTURES = 7;
     public const int ENGINE_STRUCTURE_EFFECT = 0;
     public const int ENGINE_STRUCTURE_EVENT = 1;
@@ -6003,7 +6003,7 @@ namespace NWN.Core
     ///    (If the object doesn&amp;apos;t exist, nothing happens.)
     public static void AssignCommand(uint oActionSubject, ActionDelegate aActionToAssign)
     {
-      NWNCore.GameManager.ClosureAssignCommand(oActionSubject, aActionToAssign);
+      NWNCore.FunctionHandler.ClosureAssignCommand(oActionSubject, aActionToAssign);
       // Function ID 6
     }
 
@@ -6017,7 +6017,7 @@ namespace NWN.Core
     ///  DelayCommand(fDelay, ApplyEffectToObject(DURATION_TYPE_INSTANT, eDamage, oTarget);
     public static void DelayCommand(float fSeconds, ActionDelegate aActionToDelay)
     {
-      NWNCore.GameManager.ClosureDelayCommand(OBJECT_SELF, fSeconds, aActionToDelay);
+      NWNCore.FunctionHandler.ClosureDelayCommand(OBJECT_SELF, fSeconds, aActionToDelay);
       // Function ID 7
     }
 
@@ -9107,7 +9107,7 @@ namespace NWN.Core
     ///  Do aActionToDo.
     public static void ActionDoCommand(ActionDelegate aActionToDo)
     {
-      NWNCore.GameManager.ClosureActionDoCommand(OBJECT_SELF, aActionToDo);
+      NWNCore.FunctionHandler.ClosureActionDoCommand(OBJECT_SELF, aActionToDo);
       // Function ID 294
     }
 


### PR DESCRIPTION
This should be a non-breaking change that adds a separate way of only initialising the core function handlers.

The only exception is if your "GameManager" class uses explicit interface function names.  In this case, the function simply needs to be updated to point at the correct interface:

E.g:
```cs
    uint IGameManager.ObjectSelf { get; }

    void IGameManager.OnMainLoop(ulong frame) {}
```
Becomes
```cs
   uint ICoreFunctionHandler.ObjectSelf { get; }

   void ICoreEventHandler.OnMainLoop(ulong frame) {}
```